### PR TITLE
changes to support single node clusters

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.0.3
+version: 1.1.3
 sources:
 - https://github.com/strimzi/strimzi-kafka-operator
 - https://github.com/apache/kafka

--- a/charts/kafka/templates/kafka.yml
+++ b/charts/kafka/templates/kafka.yml
@@ -11,10 +11,10 @@ spec:
       tls: {}
     config:
       num.partitions: 30
-      default.replication.factor: 3
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
+      default.replication.factor: {{ .Values.kafka.defaultReplicas }}
+      offsets.topic.replication.factor: {{ .Values.kafka.defaultReplicas }}
+      transaction.state.log.replication.factor: {{ .Values.kafka.defaultReplicas }}
+      transaction.state.log.min.isr: {{ .Values.kafka.defaultReplicas }}
       auto.create.topics.enable: false
     storage:
       type: persistent-claim
@@ -29,7 +29,7 @@ spec:
     resources:
 {{ toYaml .Values.kafka.resources | indent 6 }}
     rack:
-      topologyKey: failure-domain.beta.kubernetes.io/zone
+      topologyKey: "kubernetes.io/hostname"
     tlsSidecar:
 {{ toYaml .Values.tlsSidecar | indent 6 }}
     tolerations:

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.8.5
+version: 1.8.6
 
 dependencies:
   - name: andi


### PR DESCRIPTION
These changes support single node clusters like minikube, and updates the node selector used by strimzi to be more in line with current k8s versions.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
