### PR TITLE
Default raptor_url set in charts

### DIFF
--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.2.1
+version: 1.2.2
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -83,6 +83,8 @@ spec:
             value: {{ quote .Values.elasticsearch.tls }}
           - name: METRICS_PORT
             value: {{ quote .Values.monitoring.targetPort }}
+          - name: RAPTOR_URL
+            value: {{ quote .Values.global.auth.raptor_url }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/charts/discovery-api/values.yaml
+++ b/charts/discovery-api/values.yaml
@@ -2,7 +2,7 @@ global:
   auth:
     jwt_issuer: ""
     auth0_domain: ""
-    raptor_url: "http://raptor.admin/api/authorize"
+    raptor_url: "http://raptor/api/authorize"
   buckets:
     region: us-west-2
     hostedFileBucket: "dataset-bucket"

--- a/charts/discovery-api/values.yaml
+++ b/charts/discovery-api/values.yaml
@@ -2,6 +2,7 @@ global:
   auth:
     jwt_issuer: ""
     auth0_domain: ""
+    raptor_url: "http://raptor.admin/api/authorize"
   buckets:
     region: us-west-2
     hostedFileBucket: "dataset-bucket"

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.0.4
+version: 1.0.5
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/templates/deployment.yaml
+++ b/charts/discovery-streams/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
 {{- end }}
         - name: RUN_IN_KUBERNETES
           value: "true"
+        - name: RAPTOR_URL
+          value: {{ quote .Values.global.auth.raptor_url }}
         - name: METRICS_PORT
           value: {{ quote .Values.monitoring.targetPort }}
         - name: NAMESPACE

--- a/charts/discovery-streams/values.yaml
+++ b/charts/discovery-streams/values.yaml
@@ -11,7 +11,7 @@ global:
     dnsZone: ""
     rootDnsZone: ""
   auth:
-    raptor_url: "http://raptor.admin/api/authorize"
+    raptor_url: "http://raptor/api/authorize"
 
 dashboard:
   title: "Dashboard Metrics"

--- a/charts/discovery-streams/values.yaml
+++ b/charts/discovery-streams/values.yaml
@@ -10,6 +10,8 @@ global:
   ingress:
     dnsZone: ""
     rootDnsZone: ""
+  auth:
+    raptor_url: "http://raptor.admin/api/authorize"
 
 dashboard:
   title: "Dashboard Metrics"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 2.1.1
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.2.1
+  version: 1.2.2
 - name: discovery-streams
   repository: file://../discovery-streams
-  version: 1.0.4
+  version: 1.0.5
 - name: discovery-ui
   repository: file://../discovery-ui
   version: 1.0.1
@@ -34,7 +34,7 @@ dependencies:
   version: 1.1.1
 - name: raptor
   repository: file://../raptor
-  version: 1.1.1
+  version: 1.1.2
 - name: reaper
   repository: file://../reaper
   version: 1.2.2
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.1
-digest: sha256:c74c79152538235fbbc52f82418e59c1bd6d8b29aa906dd98b609dc576a92ca3
-generated: "2022-01-04T16:22:24.977334-06:00"
+digest: sha256:a5990c83b1a5677dfbe4d947e6de709f7e660aa4b69b267957ccae7f48c3dd5b
+generated: "2022-01-06T12:45:40.970263-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.8.7
+version: 1.8.8
 
 dependencies:
   - name: andi


### PR DESCRIPTION
## Description
Adds default values for raptor url to the global auth block

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
