### PR TITLE
Andi Version Bump (Forgotten in PR #326)

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.1.1
+version: 2.1.2
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: andi
   repository: file://../andi
-  version: 2.1.1
+  version: 2.1.2
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.2.2
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.1
-digest: sha256:a5990c83b1a5677dfbe4d947e6de709f7e660aa4b69b267957ccae7f48c3dd5b
-generated: "2022-01-06T12:45:40.970263-06:00"
+digest: sha256:0a767011c32806002fc79bdf4fcbb3ae5c43ce2744ac490171210641282379a9
+generated: "2022-01-14T15:45:35.554584-06:00"


### PR DESCRIPTION
Forgotten Andi chart version increase in PR #326 is causing charts deployments to fail.

PR #326: https://github.com/UrbanOS-Public/charts/pull/326
Failures: (Line 48 of "run chart releaser" step) https://github.com/UrbanOS-Public/charts/runs/4768298301?check_suite_focus=true#step:6:48

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?): N/A
