### PR TITLE
Redis ssl andi

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.1.2
+version: 2.1.3
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -32,7 +32,16 @@ spec:
           - name: REDIS_HOST
             value: {{ .Values.global.redis.host }}
           - name: REDIS_PASSWORD
+{{- if .Values.global.redis.passwordSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ quote .Values.global.redis.passwordSecret }}
+                key: {{ quote .Values.global.redis.passwordSecret }}
+{{- else }}
             value: {{ .Values.global.redis.password }}
+{{- end }}
+          - name: REDIS_SSL
+            value: {{ quote .Values.global.redis.sslEnabled }}
           - name: KAFKA_BROKERS
             value: {{ .Values.global.kafka.brokers | default (include "kafka.brokerservice" .) }}
           - name: METRICS_PORT
@@ -81,7 +90,7 @@ spec:
           - name: VAULT_ROLE
             value: {{ quote .Values.vaultRole | default "andi-role" }}
           - name: HOSTED_FILE_BUCKET
-            value: {{ .Values.environment }}-{{ .Values.s3.hostedFileBucket }}
+            value: {{ .Values.s3.hostedFileBucket }}
           - name: HOSTED_FILE_REGION
             value: {{ .Values.s3.hostedFileRegion }}
           - name: AUTH0_CLIENT_SECRET

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -99,6 +99,12 @@ spec:
               secretKeyRef:
                 name: {{ .Release.Name }}-andi-aws-credentials
                 key: aws_access_key_secret
+          {{ if .Values.aws.s3HostName }}
+          - name: S3_HOST_NAME
+            value: {{ .Values.aws.s3HostName }}
+          - name: S3_PORT
+            value: {{ quote .Values.aws.s3Port }}
+          {{ end -}}
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
             value: {{ .Values.postgres.password }}
           - name: POSTGRES_PORT
             value: {{ quote .Values.postgres.port }}
+          - name: POSTGRES_VERIFY_SNI
+            value: {{ quote .Values.postgres.verifySNI }}
           - name: SECRETS_ENDPOINT
             value: {{ .Values.global.vault.endpoint }}
           - name: AUTH0_DOMAIN

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
           env:
           - name: REDIS_HOST
             value: {{ .Values.global.redis.host }}
+          - name: REDIS_PORT
+            value: {{ quote .Values.global.redis.port }}
           - name: REDIS_PASSWORD
 {{- if .Values.global.redis.passwordSecret }}
             valueFrom:

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - name: POSTGRES_USER
             value: {{ .Values.postgres.user }}
           - name: POSTGRES_PASSWORD
-            value: {{ .Values.postgres.password }}
+            value: {{ quote .Values.postgres.password }}
           - name: POSTGRES_PORT
             value: {{ quote .Values.postgres.port }}
           - name: POSTGRES_VERIFY_SNI

--- a/charts/andi/templates/ingress.yaml
+++ b/charts/andi/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -30,4 +31,5 @@ spec:
         backend:
           serviceName: redirect
           servicePort: use-annotation
+{{- end }}
 {{- end }}

--- a/charts/andi/templates/secrets.yaml
+++ b/charts/andi/templates/secrets.yaml
@@ -23,5 +23,13 @@ metadata:
   name: {{ .Release.Name }}-andi-aws-credentials
 type: Opaque
 stringData:
+  {{ if .Values.global.objectStore.accessSecret }}
+  aws_access_key_secret: {{ quote .Values.global.objectStore.accessSecret }}
+  {{- else }}
   aws_access_key_secret: {{ quote .Values.aws.accessKeySecret }}
+  {{ end -}}  
+  {{ if .Values.global.objectStore.accessKey }}
+  aws_access_key_id: {{ quote .Values.global.objectStore.accessKey }}
+  {{- else }}
   aws_access_key_id: {{ quote .Values.aws.accessKeyId }}
+  {{ end -}}

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -58,8 +58,12 @@ auth:
   auth0_client_secret: ""
 
 aws:
+  # Overriden by global.objectStore.accessKey if present
   accessKeyId: ""
+  # Overriden by global.objectStore.accessSecret if present
   accessKeySecret: ""
+  s3HostName: null
+  s3Port: null
 
 # The root at which documentation pdfs and other artifacts can be found
 documentationRoot: ""

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -55,6 +55,7 @@ postgres:
   dbname: "postgres"
   user: "postgres"
   password: "password"
+  verifySNI: true
 
 auth:
   auth0_client_id: ""

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -83,4 +83,5 @@ s3:
 vaultRole: "andi-role"
 
 ingress:
+  enabled: true
   annotations:

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -7,8 +7,11 @@ global:
   presto:
     url: http://platform-kubernetes-data-platform-presto:8080
   redis:
-    host: redis.external-services 
+    host: redis.external-services
+    port: 6379
+    passwordSecret: ""
     password: ""
+    sslEnabled: false
   vault:
     endpoint: vault.vault:8200
   ingress:

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           - name: POSTGRES_USER
             value: {{ .Values.postgres.user }}
           - name: POSTGRES_PASSWORD
-            value: {{ .Values.postgres.password }}
+            value: {{ quote .Values.postgres.password }}
           - name: POSTGRES_PORT
             value: {{ quote .Values.postgres.port }}
           - name: POSTGRES_VERIFY_SNI

--- a/charts/discovery-api/values.yaml
+++ b/charts/discovery-api/values.yaml
@@ -21,6 +21,10 @@ global:
   ingress:
     rootDnsZone: localhost
     dnsZone: localhost
+  objectStore:
+    accessSecret: ""
+    accessKey: ""
+
 resources:
   limits:
     memory: 512Mi
@@ -87,7 +91,9 @@ secrets:
   guardianSecretKey: ""
 
 aws:
+  # Overriden by global.objectStore.accessKey if present
   accessKeyId: ""
+  # Overriden by global.objectStore.accessSecret if present
   accessKeySecret: ""
   s3HostName: null
   s3Port: null

--- a/charts/discovery-ui/templates/ingress.yaml
+++ b/charts/discovery-ui/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -35,3 +36,4 @@ spec:
         backend:
           serviceName: redirect
           servicePort: use-annotation
+{{- end }}

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -34,4 +34,5 @@ tolerations: []
 affinity: {}
 
 ingress:
+  enabled: true
   annotations:

--- a/charts/forklift/templates/deployment.yaml
+++ b/charts/forklift/templates/deployment.yaml
@@ -77,9 +77,9 @@ spec:
           {{ end -}}
           {{ if .Values.s3HostName }}
           - name: S3_HOST_NAME
-            value: {{ .Values.s3HostName }}
+            value: {{ .Values.aws.s3HostName }}
           - name: S3_PORT
-            value: {{ .Values.s3Port | quote }}
+            value: {{ .Values.aws.s3Port | quote }}
           {{ end -}}
           {{ if .Values.global.buckets.hiveStorageBucket }}
           - name: S3_WRITER_BUCKET

--- a/charts/forklift/values.yaml
+++ b/charts/forklift/values.yaml
@@ -36,8 +36,9 @@ kafka:
   dataTopicPrefix: "transformed"
   outputTopic: "streaming-persisted"
 
-s3HostName: null
-s3Port: null
+aws:
+  s3HostName: null
+  s3Port: null
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Changes:

(Individual commits are well documented)

- Add Redis SSL Values
- New Postgres + Bucket Values
- Optional ingress
- AWS Secrets able to be set from global, documented as such in values file.
  - Made sure discovery-api behaves the same way / is documented the same
- Altered some AWS forklift values so that it aligns with the way AWS values are configured elsewhere

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
