### PR TITLE
Bumping monitoring version because odo is gone

### DIFF
--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: "A combination of the community Prometheus and Grafana charts."
 name: monitoring
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   - name: prometheus

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 1.6.1
 - name: monitoring
   repository: file://../monitoring
-  version: 1.0.2
+  version: 1.0.3
 - name: raptor
   repository: file://../raptor
   version: 1.1.2
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.1
-digest: sha256:61a5e1cf95c7f652a6df2ad6549f0b581e3fd7c23e45610ab810bf0d4640a5d9
-generated: "2022-02-18T12:42:35.401589-05:00"
+digest: sha256:04d289993676e05d6ebe27a0c7e88b24e0ca155ddead110c98f40169ccc242df
+generated: "2022-02-18T12:49:15.526349-05:00"


### PR DESCRIPTION
## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
