### PR TITLE
Add redis ssl config, like alchemist and the rest

### DIFF
--- a/charts/valkyrie/Chart.yaml
+++ b/charts/valkyrie/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Validates data from raw topic and writes it to validated topic
 name: valkyrie
-version: 2.6.2
+version: 2.6.3
 sources:
-- https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/valkyrie
+  - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/valkyrie

--- a/charts/valkyrie/templates/deployment.yaml
+++ b/charts/valkyrie/templates/deployment.yaml
@@ -40,8 +40,19 @@ spec:
             value: {{.Values.kafka.dlqTopic}}
           - name: REDIS_HOST
             value: {{ .Values.global.redis.host }}
+          - name: REDIS_PORT
+            value: {{ quote .Values.global.redis.port }}
           - name: REDIS_PASSWORD
+{{- if .Values.global.redis.passwordSecret }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ quote .Values.global.redis.passwordSecret }}
+                key: {{ quote .Values.global.redis.passwordSecret }}
+{{- else }}
             value: {{ .Values.global.redis.password }}
+{{- end }}
+          - name: REDIS_SSL
+            value: {{ quote .Values.global.redis.sslEnabled }}
           - name: PROCESSOR_STAGES
             value: {{ .Values.processor_stages | quote }}
           - name: PROFILING_ENABLED

--- a/charts/valkyrie/values.yaml
+++ b/charts/valkyrie/values.yaml
@@ -3,7 +3,10 @@ global:
     brokers: streaming-service-kafka-bootstrap:9092
   redis:
     host: redis.external-services
+    port: 6379
     password: ""
+    passwordSecret: ""
+    sslEnabled: false
 
 replicaCount: 2
 


### PR DESCRIPTION
Add the same redis ssl config that other apps have.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
