### PR TITLE
Openshift chart updates

### DIFF
--- a/charts/alchemist/Chart.yaml
+++ b/charts/alchemist/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Transforms data from the raw topic and writes it to transformed topic
 name: alchemist
-version: 1.0.0
+version: 1.0.1
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/alchemist

--- a/charts/alchemist/templates/cluster-rbac.yaml
+++ b/charts/alchemist/templates/cluster-rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.1.3
+version: 2.1.4
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/templates/rbac.yaml
+++ b/charts/andi/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "helm.fullname" . }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "helm.fullname" . }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "helm.fullname" . }}

--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.2.3
+version: 1.2.4
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/templates/rbac.yaml
+++ b/charts/discovery-api/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.0.5
+version: 1.0.6
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/templates/rbac.yaml
+++ b/charts/discovery-streams/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/forklift/Chart.yaml
+++ b/charts/forklift/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Loads data from the transformed topic into Presto
 name: forklift
-version: 3.1.4
+version: 3.1.5
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift

--- a/charts/forklift/templates/rbac.yaml
+++ b/charts/forklift/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.1.3
+version: 1.1.4
 sources:
 - https://github.com/strimzi/strimzi-kafka-operator
 - https://github.com/apache/kafka

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -8,5 +8,5 @@ sources:
 - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.22.0
+    version: 0.23.0
     repository: http://strimzi.io/charts/

--- a/charts/kafka/templates/kafka-patcher.yaml
+++ b/charts/kafka/templates/kafka-patcher.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: kafka-patcher
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kafka-patcher
@@ -15,7 +15,7 @@ rules:
       - get
       - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kafka-patcher-binding

--- a/charts/kafka/templates/kafka.yml
+++ b/charts/kafka/templates/kafka.yml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: pipeline
@@ -7,8 +7,10 @@ spec:
     version: {{ .Values.kafka.version }}
     replicas: {{ .Values.kafka.defaultReplicas }}
     listeners:
-      plain: {}
-      tls: {}
+    - name: plain
+      port: 9092
+      type: internal
+      tls: false
     config:
       num.partitions: 30
       default.replication.factor: {{ .Values.kafka.defaultReplicas }}
@@ -30,12 +32,6 @@ spec:
 {{ toYaml .Values.kafka.resources | indent 6 }}
     rack:
       topologyKey: "kubernetes.io/hostname"
-    tlsSidecar:
-{{ toYaml .Values.tlsSidecar | indent 6 }}
-    tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-    affinity:
-{{ toYaml .Values.affinity | indent 6 }}
   zookeeper:
     replicas: {{ .Values.kafka.defaultReplicas }}
     readinessProbe:
@@ -55,12 +51,6 @@ spec:
       limits:
         cpu: 100m
         memory: 512Mi
-    tlsSidecar:
-{{ toYaml .Values.tlsSidecar | indent 6 }}
-    tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-    affinity:
-{{ toYaml .Values.affinity | indent 6 }}
   entityOperator:
     topicOperator:
       resources:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -1,5 +1,5 @@
 kafka:
-  version: 2.5.1
+  version: 2.6.2
   broker: pipeline-kafka-bootstrap:9092
   storageSize: 100Gi
   defaultPartitions: 1

--- a/charts/raptor/Chart.yaml
+++ b/charts/raptor/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Authenticate and authorize API users
 name: raptor
-version: 1.1.2
+version: 1.1.3
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/raptor

--- a/charts/raptor/templates/rbac.yaml
+++ b/charts/raptor/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/raptor/values.yaml
+++ b/charts/raptor/values.yaml
@@ -35,4 +35,4 @@ monitoring:
 service:
   type: NodePort
   port: 80
-  targetPort: 80
+  targetPort: 4000

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 name: reaper
-version: 1.2.3
+version: 1.2.4
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/reaper

--- a/charts/reaper/templates/rbac.yaml
+++ b/charts/reaper/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.10.1
+version: 1.10.2
 
 dependencies:
   - name: alchemist

--- a/charts/valkyrie/Chart.yaml
+++ b/charts/valkyrie/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Validates data from raw topic and writes it to validated topic
 name: valkyrie
-version: 2.6.3
+version: 2.6.4
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/valkyrie

--- a/charts/valkyrie/templates/cluster-rbac.yaml
+++ b/charts/valkyrie/templates/cluster-rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Chart.Name }}
@@ -16,7 +16,7 @@ rules:
       - watch
       - list
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Chart.Name }}


### PR DESCRIPTION
Big changes:

1. Kafka version update to support k8s 1.22
2. ApiVersion updates for the same reason

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
