### PR TITLE
Small chart updates (missing default values)

### DIFF
--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.1
+version: 1.4.2
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -47,7 +47,11 @@ spec:
           - name: PRESTO_SCHEMA
             value: {{ .Values.presto.schema }}
           - name: HOST
+{{- if .Release.Namespace }}
+            value: data.{{ .Release.Namespace }}.{{ .Values.global.ingress.rootDnsZone }}
+{{- else }}
             value: data.{{ .Values.global.ingress.rootDnsZone }}
+{{- end }}
           - name: ALLOWED_ORIGINS
             value: {{ .Values.global.ingress.rootDnsZone }},{{ .Values.global.ingress.dnsZone }}
           - name: PRESIGN_KEY

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.2.0
+version: 1.2.1
 sources:
-- https://github.com/UrbanOS-Public/discovery_ui
-- https://github.com/UrbanOS-Public/react_discovery_ui
+  - https://github.com/UrbanOS-Public/discovery_ui
+  - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/templates/deployment.yaml
+++ b/charts/discovery-ui/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: discovery-ui
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: "API_HOST"
             value: {{ .Values.env.api_host }}

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -14,6 +14,7 @@ image:
   name: smartcolumbusos/discovery_ui
   tag: development
   environment: "local"
+  pullPolicy: always
 
 env:
   api_host: "https://data.example.com"

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -21,6 +21,7 @@ env:
   gtm_id: "GTM-EXAMPLE"
   base_url: "example.com"
   streets_tile_layer_url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+  logo_url: null
   mapbox_access_token: ""
   auth0_domain: ""
   auth0_client_id: ""


### PR DESCRIPTION
## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
