### PR TITLE
Bumping version

### DIFF
--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.11.4
+version: 1.11.5
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Reminders

- [x Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
