### PR TITLE
Adjust zookeeperResources to zookeeper.resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 requirements.lock
 tmp_charts/
 charts/urban-os/charts
+charts/kafka/charts
 
 .DS_Store
 

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.2.1
+version: 1.2.2
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -14,7 +14,7 @@ image:
   name: smartcolumbusos/discovery_ui
   tag: development
   environment: "local"
-  pullPolicy: always
+  pullPolicy: Always
 
 env:
   api_host: "https://data.example.com"

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.1.5
+version: 1.1.6
 sources:
-- https://github.com/strimzi/strimzi-kafka-operator
-- https://github.com/apache/kafka
+  - https://github.com/strimzi/strimzi-kafka-operator
+  - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
     version: 0.23.0

--- a/charts/kafka/templates/kafka.yml
+++ b/charts/kafka/templates/kafka.yml
@@ -45,7 +45,7 @@ spec:
       size: 1Gi
       deleteClaim: false
     resources:
-{{ toYaml .Values.kafka.zookeeperResources | indent 6 }}
+{{ toYaml .Values.zookeeper.resources | indent 6 }}
   entityOperator:
     topicOperator:
       resources:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -16,7 +16,9 @@ kafka:
     limits:
       cpu: 1400m
       memory: 12500M
-  zookeeperResources:
+
+zookeeper:
+  resources:
     requests:
       cpu: 100m
       memory: 512Mi

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.1
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.2.1
+  version: 1.2.2
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.6
 - name: kafka
   repository: file://../kafka
-  version: 1.1.5
+  version: 1.1.6
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.1
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.2
-digest: sha256:83b6649439ba35997c835e140091c14c084d90ec85d1d50d9939751696fb2575
-generated: "2022-05-31T15:06:42.882266-06:00"
+digest: sha256:9699286141eb250dc5b534689737f534c632f04de824759ab4fe14dcea92b5b6
+generated: "2022-06-01T11:20:30.796543-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.11.4
+version: 1.11.5
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Description

- Adding new commands to the local-deploy-script ensures that the strimzi dependencies will always be present 
- Renames zookeeperResources to zookeeper.resources

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and committed the Chart.lock file?
