### PR TITLE
Use configmap for nginx ubi image configuration

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.2.2
+version: 1.3.0
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -17,36 +17,28 @@ data:
     window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
   default.conf: |
-    server {
-      listen       8080;
-      server_name  localhost;
-      add_header X-Content-Type-Options nosniff;
-      add_header X-XSS-Protection "1; mode=block";
-      add_header X-Frame-Options "DENY";
-      add_header Cache-Control "no-cache, no-store, must-revalidate";
-      add_header Pragma "no-cache";
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.smartcolumbusos.com {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
-      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    server_name  localhost;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Frame-Options "DENY";
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    add_header Pragma "no-cache";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.smartcolumbusos.com {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
-      server_tokens off;
+    server_tokens off;
 
-      gzip on;
-      gzip_static on;
-      gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-      gzip_proxied  any;
-      gzip_vary on;
-      gzip_comp_level 6;
-      gzip_buffers 16 8k;
-      gzip_http_version 1.1;
+    gzip on;
+    gzip_static on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_proxied  any;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
 
-      root   /usr/share/nginx/html;
-      index  index.html index.htm;
-      location / {
-        try_files $uri $uri/ /index.html;
-      }
+    index  index.html index.htm;
 
-      error_page   500 502 503 504  /50x.html;
-      location = /50x.html {
-          root   /usr/share/nginx/html;
-      }
+    location / {
+      try_files $uri $uri/ /index.html;
     }

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: discovery-ui-configs
+data:
+  config.js: |
+    window.API_HOST = '{{.Values.env.api_host}}'
+    {{ if .Values.env.contribute_host }}
+    window.CONTRIBUTE_HOST = '{{.Values.env.contribute_host}}'
+    {{ end -}}
+    window.GTM_ID = '{{.Values.env.gtm_id}}'
+    window.BASE_URL = '{{.Values.env.base_url}}'
+    window.STREETS_TILE_LAYER_URL = '{{.Values.env.streets_tile_layer_url}}'
+    window.MAPBOX_ACCESS_TOKEN = '{{.Values.env.mapbox_access_token}}'
+    window.LOGO_URL = '{{.Values.env.logo_url}}'
+    window.AUTH0_DOMAIN = '{{.Values.global.auth.auth0_domain}}'
+    window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'
+    window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
+  default.conf: |
+    server {
+      listen       8080;
+      server_name  localhost;
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection "1; mode=block";
+      add_header X-Frame-Options "DENY";
+      add_header Cache-Control "no-cache, no-store, must-revalidate";
+      add_header Pragma "no-cache";
+      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.smartcolumbusos.com {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+
+      server_tokens off;
+
+      gzip on;
+      gzip_static on;
+      gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+      gzip_proxied  any;
+      gzip_vary on;
+      gzip_comp_level 6;
+      gzip_buffers 16 8k;
+      gzip_http_version 1.1;
+
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      location / {
+        try_files $uri $uri/ /index.html;
+      }
+
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+    }

--- a/charts/discovery-ui/templates/deployment.yaml
+++ b/charts/discovery-ui/templates/deployment.yaml
@@ -22,10 +22,10 @@ spec:
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-        - mountPath: /usr/share/nginx/html/config.js
+        - mountPath: /opt/app-root/src/config.js
           name: discovery-ui-configs
           subPath: config.js
-        - mountPath: /etc/nginx/conf.d/default.conf
+        - mountPath: /opt/app-root/etc/nginx.default.d/default.conf
           name: discovery-ui-configs
           subPath: default.conf
       volumes:

--- a/charts/discovery-ui/templates/deployment.yaml
+++ b/charts/discovery-ui/templates/deployment.yaml
@@ -21,31 +21,17 @@ spec:
       - name: discovery-ui
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        env:
-          - name: "API_HOST"
-            value: {{ .Values.env.api_host }}
-          - name: "GTM_ID"
-            value: {{ .Values.env.gtm_id }}
-          - name: "BASE_URL"
-            value: {{ .Values.env.base_url }}
-          - name: "STREETS_TILE_LAYER_URL"
-            value: {{ .Values.env.streets_tile_layer_url }}
-          - name: "LOGO_URL"
-            value: {{ .Values.env.logo_url | default "null" }}
-          - name: "MAPBOX_ACCESS_TOKEN"
-            value: {{ .Values.env.mapbox_access_token }}
-          - name: "AUTH0_DOMAIN"
-            value: {{ .Values.global.auth.auth0_domain }}
-          - name: "AUTH0_CLIENT_ID"
-            value: {{ .Values.env.auth0_client_id }}
-          - name: "AUTH0_AUDIENCE"
-            value: {{ .Values.env.auth0_audience }}
-          - name: "ADDITIONAL_CSP_HOSTS"
-            value: "{{ .Values.env.additional_csp_hosts }}"
-          {{ if .Values.env.contribute_host }}
-          - name: CONTRIBUTE_HOST
-            value: {{.Values.env.contribute_host | quote }}
-          {{ end -}}
+        volumeMounts:
+        - mountPath: /usr/share/nginx/html/config.js
+          name: discovery-ui-configs
+          subPath: config.js
+        - mountPath: /etc/nginx/conf.d/default.conf
+          name: discovery-ui-configs
+          subPath: default.conf
+      volumes:
+      - name: discovery-ui-configs
+        configMap:
+          name: discovery-ui-configs
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.1
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.2.2
+  version: 1.3.0
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.2
-digest: sha256:9699286141eb250dc5b534689737f534c632f04de824759ab4fe14dcea92b5b6
-generated: "2022-06-01T11:20:30.796543-06:00"
+digest: sha256:4e311a2fe41ec648664a8df58f6fc3435b54a9934537bab6dbfc9f3216976275
+generated: "2022-06-07T13:51:47.953134-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.11.5
+version: 1.11.6
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
[Ticket Link](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/711)

## Description

- Uses config maps to configure nginx server properties. This was previously done in the discovery_ui image itself.
- Uses config maps for the config.js values as well.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
