### PR TITLE
Remove values related to compaction 2.0 opt in + overwrite_mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Reminders
 
 - [ ] Did you up the relevant chart version numbers? (If appropriate)
+  - [ ] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
 - [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
-- [ ] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
+  - [ ] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?

--- a/charts/forklift/Chart.yaml
+++ b/charts/forklift/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Loads data from the transformed topic into Presto
 name: forklift
-version: 3.1.6
+version: 3.1.7
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift

--- a/charts/forklift/README.md
+++ b/charts/forklift/README.md
@@ -14,6 +14,7 @@ Loads data from the transformed topic into Presto
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | compactionSchedule | string | `"0 * * * *"` |  |
+| overwrite_mode | bool | `false` | When enabled, forklift doesn't retain any past records for a dataset. New records replace what was previously stored. |
 | fullnameOverride | string | `""` |  |
 | global.kafka.brokers | string | `"streaming-service-kafka-bootstrap:9092"` |  |
 | global.objectStore.accessKey | string | `nil` |  |

--- a/charts/forklift/README.md
+++ b/charts/forklift/README.md
@@ -39,7 +39,6 @@ Loads data from the transformed topic into Presto
 | s3HostName | string | `nil` |  |
 | s3Port | string | `nil` |  |
 | service.type | string | `"ClusterIP"` |  |
-| specialCompactionDatasets | string | `nil` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/forklift/templates/deployment.yaml
+++ b/charts/forklift/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           - name: AWS_ACCESS_KEY_ID
             value: {{ .Values.global.objectStore.accessKey }}
           {{ end -}}
+          {{ if .Values.overwrite_mode }}
+          - name: OVERWRITE_MODE
+            value: true
+          {{ end -}}
           {{ if .Values.global.objectStore.accessSecret }}
           - name: AWS_SECRET_ACCESS_KEY
             value: {{ .Values.global.objectStore.accessSecret }}

--- a/charts/forklift/templates/deployment.yaml
+++ b/charts/forklift/templates/deployment.yaml
@@ -63,10 +63,6 @@ spec:
           - name: COMPACTION_SCHEDULE
             value: {{.Values.compactionSchedule | quote }}
           {{ end -}}
-          {{ if .Values.specialCompactionDatasets }}
-          - name: SPECIAL_COMPACTION_DATASETS
-            value: {{.Values.specialCompactionDatasets | quote }}
-          {{ end -}}
           {{ if .Values.global.objectStore.accessKey }}
           - name: AWS_ACCESS_KEY_ID
             value: {{ .Values.global.objectStore.accessKey }}

--- a/charts/forklift/values.yaml
+++ b/charts/forklift/values.yaml
@@ -56,6 +56,3 @@ profiling_enabled: false
 
 # Set compactionSchedule to a valid cron string such as "00 01 * * *" (This will run compaction nightly at 1:00am)
 compactionSchedule: "0 * * * *"
-# Special compaction datasets use the variant compaction introduced in https://github.com/Datastillery/smartcitiesdata/pull/950
-# This is a comma seperated list of dataset ids, and will only be used if a compactionSchedule is provided. WARNING: tables will be mutated to enable the variant compaction process
-specialCompactionDatasets: null

--- a/charts/forklift/values.yaml
+++ b/charts/forklift/values.yaml
@@ -54,5 +54,9 @@ monitoring:
 
 profiling_enabled: false
 
+# When enabled, forklift doesn't retain any past records for a dataset.
+# New records replace what was previously stored.
+overwrite_mode: false
+
 # Set compactionSchedule to a valid cron string such as "00 01 * * *" (This will run compaction nightly at 1:00am)
 compactionSchedule: "0 * * * *"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 1.0.1
 - name: forklift
   repository: file://../forklift
-  version: 3.1.6
+  version: 3.1.7
 - name: kafka
   repository: file://../kafka
   version: 1.1.6
@@ -44,5 +44,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.2
-digest: sha256:4e311a2fe41ec648664a8df58f6fc3435b54a9934537bab6dbfc9f3216976275
-generated: "2022-06-07T13:51:47.953134-06:00"
+digest: sha256:b9b2170b498c18cc141561c6c617b199fae58d59ad80ed4c10e567eba39c8d94
+generated: "2022-07-12T10:36:45.701973-06:00"


### PR DESCRIPTION
## Description

Forklift:
- Removes "special compaction" related values as that is now the default
- Adds "overwrite_mode" as an option

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [x] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
