### PR TITLE
metastore-image-fix

### DIFF
--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v1
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: trino
     version: 0.8.0

--- a/charts/persistence/templates/metastore-deployment.yaml
+++ b/charts/persistence/templates/metastore-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: hive-metastore
       containers:
       - name: hive-metastore
-        image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-008
+        image: {{ .Values.metastore.image }}
         ports:
         - containerPort: 8000
         env:

--- a/charts/persistence/values.yaml
+++ b/charts/persistence/values.yaml
@@ -8,6 +8,7 @@ global:
     hiveStoragePath: 
 
 metastore:
+  image: quay.io/cloudservices/ubi-hive:3.1.2-metastore-009
   postgres:
     user: padmin
     password: example

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 1.7.1
 - name: persistence
   repository: file://../persistence
-  version: 1.0.0
+  version: 1.0.1
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.0
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.2
-digest: sha256:1047419eb91697c50c969edd879e6e73c6a984e3163a69751b6d7660206ed1af
-generated: "2022-07-28T16:07:25.453713-04:00"
+digest: sha256:a4d3f268f4047aee31a02499c860a8a6647350f1450060a72ab7bd9fe292cb5d
+generated: "2022-08-02T16:50:51.121157-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.0
+version: 1.12.1
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [ ] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
