### PR TITLE
Up previously forgotten chart versions

### DIFF
--- a/charts/kubernetes-data-platform/Chart.yaml
+++ b/charts/kubernetes-data-platform/Chart.yaml
@@ -1,15 +1,15 @@
 name: kubernetes-data-platform
 apiVersion: v1
 description: Hadoop-less data platform for the Smart City OS
-version: 1.7.1
+version: 1.7.2
 keywords:
-- presto
-- hive-metastore
-- cloud-object-store
-- minio
+  - presto
+  - hive-metastore
+  - cloud-object-store
+  - minio
 sources:
-- https://github.com/UrbanOS-Public/kdp
-- https://github.com/prestodb/presto
-- https://github.com/apache/hive
-- https://github.com/minio/minio
-- https://github.com/helm/helm
+  - https://github.com/UrbanOS-Public/kdp
+  - https://github.com/prestodb/presto
+  - https://github.com/apache/hive
+  - https://github.com/minio/minio
+  - https://github.com/helm/helm

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -28,7 +28,7 @@ dependencies:
   version: 1.1.6
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
-  version: 1.7.1
+  version: 1.7.2
 - name: persistence
   repository: file://../persistence
   version: 1.0.0
@@ -46,6 +46,6 @@ dependencies:
   version: 2.6.4
 - name: vault
   repository: file://../vault
-  version: 1.3.2
-digest: sha256:1047419eb91697c50c969edd879e6e73c6a984e3163a69751b6d7660206ed1af
-generated: "2022-07-28T16:07:25.453713-04:00"
+  version: 1.3.3
+digest: sha256:58015578a68b84d31f3f72e04dbada1473ad7b3a0cc23dcfa060af2bd7799555
+generated: "2022-08-05T16:29:11.580305-06:00"

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A custom chart for the vault secrets engine in support of the UrbanOS platform.
 name: vault
-version: 1.3.2
+version: 1.3.3
 sources:
-- https://github.com/hashicorp/vault
+  - https://github.com/hashicorp/vault


### PR DESCRIPTION
## Description
- Add chart values that were forgotten in https://github.com/UrbanOS-Public/charts/pull/359. CI/CD is failing due to chart version conflicts.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [x] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
