### PR TITLE
Remove compaction schedule value from forklift chart values

### DIFF
--- a/charts/forklift/Chart.yaml
+++ b/charts/forklift/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Loads data from the transformed topic into Presto
 name: forklift
-version: 3.1.7
+version: 3.1.8
 sources:
-- https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift
+  - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift

--- a/charts/forklift/README.md
+++ b/charts/forklift/README.md
@@ -13,7 +13,6 @@ Loads data from the transformed topic into Presto
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| compactionSchedule | string | `"0 * * * *"` |  |
 | overwrite_mode | bool | `false` | When enabled, forklift doesn't retain any past records for a dataset. New records replace what was previously stored. |
 | fullnameOverride | string | `""` |  |
 | global.kafka.brokers | string | `"streaming-service-kafka-bootstrap:9092"` |  |

--- a/charts/forklift/templates/deployment.yaml
+++ b/charts/forklift/templates/deployment.yaml
@@ -59,10 +59,6 @@ spec:
             value: {{ quote .Values.monitoring.targetPort }}
           - name: PROFILING_ENABLED
             value: {{ .Values.profiling_enabled | quote }}
-          {{ if .Values.compactionSchedule }}
-          - name: COMPACTION_SCHEDULE
-            value: {{.Values.compactionSchedule | quote }}
-          {{ end -}}
           {{ if .Values.global.objectStore.accessKey }}
           - name: AWS_ACCESS_KEY_ID
             value: {{ .Values.global.objectStore.accessKey }}

--- a/charts/forklift/values.yaml
+++ b/charts/forklift/values.yaml
@@ -57,6 +57,3 @@ profiling_enabled: false
 # When enabled, forklift doesn't retain any past records for a dataset.
 # New records replace what was previously stored.
 overwrite_mode: false
-
-# Set compactionSchedule to a valid cron string such as "00 01 * * *" (This will run compaction nightly at 1:00am)
-compactionSchedule: "0 * * * *"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 1.0.1
 - name: forklift
   repository: file://../forklift
-  version: 3.1.7
+  version: 3.1.8
 - name: kafka
   repository: file://../kafka
   version: 1.1.6
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.3
-digest: sha256:58015578a68b84d31f3f72e04dbada1473ad7b3a0cc23dcfa060af2bd7799555
-generated: "2022-08-05T16:29:11.580305-06:00"
+digest: sha256:99bd78b816b6140a83f87367f18f357850e56277399635765093fbb5be514257
+generated: "2022-09-13T00:30:51.510297-06:00"


### PR DESCRIPTION
## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [x] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
