### PR TITLE
Updated urban-os dependencies

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.1
 - name: andi
   repository: file://../andi
-  version: 2.2.1
+  version: 2.2.2
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.2
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.3
-digest: sha256:99bd78b816b6140a83f87367f18f357850e56277399635765093fbb5be514257
-generated: "2022-09-13T00:30:51.510297-06:00"
+digest: sha256:c6ace42cae0fccfe44c5891ee0e40acd1321f2161784b4ccb590b0cf0409c633
+generated: "2022-09-16T14:39:37.320931-04:00"


### PR DESCRIPTION
## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [ ] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
