### PR TITLE
Bumped urban-os version

### DIFF
--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.0
+version: 1.12.1
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If chart versions have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [ ] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
