### PR TITLE
Adding dependency update to persistence within github action releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
           helm repo add urbanos https://urbanos-public.github.io/charts
           helm repo add elastic https://helm.elastic.co
           helm repo add strimzi http://strimzi.io/charts/
+          helm repo add trinodb https://trinodb.github.io/charts/
           helm repo update
           helm dependency update charts/kafka
+          helm dependency update charts/persistence
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.4
+version: 1.12.5
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Reminders

- [ - ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ - ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
  - [ ] Additionally, was the list of values in the chart readme documentation updated to reflect the changes?
