### PR TITLE
Bumped version for all new releases

### DIFF
--- a/charts/alchemist/Chart.yaml
+++ b/charts/alchemist/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Transforms data from the raw topic and writes it to transformed topic
 name: alchemist
-version: 1.0.1
+version: 1.0.2
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/alchemist

--- a/charts/alchemist/README.md
+++ b/charts/alchemist/README.md
@@ -1,6 +1,6 @@
 # alchemist
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Transforms data from the raw topic and writes it to transformed topic
 

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.3](https://img.shields.io/badge/Version-2.2.3-informational?style=flat-square)
+![Version: 2.2.4](https://img.shields.io/badge/Version-2.2.4-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.2
+version: 1.4.3
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/README.md
+++ b/charts/discovery-api/README.md
@@ -1,6 +1,6 @@
 # discovery-api
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 A middleware layer to connect data consumers with the data sources
 

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.1.1
+version: 1.1.2
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/README.md
+++ b/charts/discovery-streams/README.md
@@ -1,6 +1,6 @@
 # discovery-streams
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Dynamically find kafka topics and makes available corresponding channels on a public websocket
 

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.3.0
+version: 1.3.1
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/estuary/Chart.yaml
+++ b/charts/estuary/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Reads the event stream and stores them in to event_stream table
 name: estuary
-version: 0.5.3
+version: 0.5.4
 deprecated: true

--- a/charts/estuary/README.md
+++ b/charts/estuary/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square)
+![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square)
 
 Reads the event stream and stores them in to event_stream table
 

--- a/charts/external-services/Chart.yaml
+++ b/charts/external-services/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart for external services. This is an optional abstraction layer for external dependencies such as redis.
 name: external-services
-version: 1.0.1
+version: 1.0.2

--- a/charts/external-services/README.md
+++ b/charts/external-services/README.md
@@ -1,6 +1,6 @@
 # external-services
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for external services. This is an optional abstraction layer for external dependencies such as redis.
 

--- a/charts/flair/Chart.yaml
+++ b/charts/flair/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: Watches data on the validated topic and does profiling on its path through the data pipeline.
 name: flair
-version: 2.1.1
+version: 2.1.2
 deprecated: true

--- a/charts/flair/README.md
+++ b/charts/flair/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 Watches data on the validated topic and does profiling on its path through the data pipeline.
 

--- a/charts/forklift/Chart.yaml
+++ b/charts/forklift/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Loads data from the transformed topic into Presto
 name: forklift
-version: 3.1.10
+version: 3.1.11
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift

--- a/charts/forklift/README.md
+++ b/charts/forklift/README.md
@@ -1,6 +1,6 @@
 # forklift
 
-![Version: 3.1.10](https://img.shields.io/badge/Version-3.1.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 3.1.11](https://img.shields.io/badge/Version-3.1.11-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Loads data from the transformed topic into Presto
 

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.1.7
+version: 1.1.8
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 

--- a/charts/kubernetes-data-platform/Chart.yaml
+++ b/charts/kubernetes-data-platform/Chart.yaml
@@ -1,7 +1,7 @@
 name: kubernetes-data-platform
 apiVersion: v1
 description: Hadoop-less data platform for the Smart City OS
-version: 1.7.2
+version: 1.7.3
 keywords:
   - presto
   - hive-metastore

--- a/charts/kubernetes-data-platform/README.md
+++ b/charts/kubernetes-data-platform/README.md
@@ -1,6 +1,6 @@
 # kubernetes-data-platform
 
-![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square)
+![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square)
 
 Hadoop-less data platform for the Smart City OS
 

--- a/charts/micro-service-watchinator/Chart.yaml
+++ b/charts/micro-service-watchinator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron job to watch microservices and make sure they are alive
 name: micro-service-watchinator
-version: 1.1.1
+version: 1.1.2
 deprecated: true

--- a/charts/micro-service-watchinator/README.md
+++ b/charts/micro-service-watchinator/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron job to watch microservices and make sure they are alive
 

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: "A combination of the community Prometheus and Grafana charts."
 name: monitoring
-version: 1.1.0
+version: 1.1.1
 
 dependencies:
   - name: prometheus

--- a/charts/monitoring/README.md
+++ b/charts/monitoring/README.md
@@ -1,6 +1,6 @@
 # monitoring
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A combination of the community Prometheus and Grafana charts.
 

--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v1
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.0
+version: 1.0.1
 dependencies:
   - name: trino
     version: 0.8.0

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 

--- a/charts/raptor/Chart.yaml
+++ b/charts/raptor/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Authenticate and authorize API users
 name: raptor
-version: 1.1.3
+version: 1.1.4
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/raptor

--- a/charts/raptor/README.md
+++ b/charts/raptor/README.md
@@ -1,6 +1,6 @@
 # raptor
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Authenticate and authorize API users
 

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 name: reaper
-version: 1.2.4
+version: 1.2.5
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/reaper

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -1,6 +1,6 @@
 # reaper
 
-![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -1,51 +1,51 @@
 dependencies:
 - name: alchemist
   repository: file://../alchemist
-  version: 1.0.1
+  version: 1.0.2
 - name: andi
   repository: file://../andi
   version: 2.2.4
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.4.2
+  version: 1.4.3
 - name: discovery-streams
   repository: file://../discovery-streams
-  version: 1.1.1
+  version: 1.1.2
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.3.0
+  version: 1.3.1
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
 - name: external-services
   repository: file://../external-services
-  version: 1.0.1
+  version: 1.0.2
 - name: forklift
   repository: file://../forklift
-  version: 3.1.10
+  version: 3.1.11
 - name: kafka
   repository: file://../kafka
-  version: 1.1.7
+  version: 1.1.8
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
-  version: 1.7.2
+  version: 1.7.3
 - name: persistence
   repository: file://../persistence
-  version: 1.0.0
+  version: 1.0.1
 - name: monitoring
   repository: file://../monitoring
-  version: 1.1.0
+  version: 1.1.1
 - name: raptor
   repository: file://../raptor
-  version: 1.1.3
+  version: 1.1.4
 - name: reaper
   repository: file://../reaper
-  version: 1.2.4
+  version: 1.2.5
 - name: valkyrie
   repository: file://../valkyrie
-  version: 2.6.4
+  version: 2.6.5
 - name: vault
   repository: file://../vault
-  version: 1.3.3
-digest: sha256:cab293eb9300617d46220779bc3569f6558f26748694cce5f2484c55ab340b5e
-generated: "2022-09-23T14:47:37.506056-05:00"
+  version: 1.3.4
+digest: sha256:4aefb9bd98698c546ab5bc365fd92c2a040ff061b63244747b09c75183d766aa
+generated: "2022-09-26T13:43:37.44666-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.6
+version: 1.12.7
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.6](https://img.shields.io/badge/Version-1.12.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.7](https://img.shields.io/badge/Version-1.12.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 

--- a/charts/valkyrie/Chart.yaml
+++ b/charts/valkyrie/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Validates data from raw topic and writes it to validated topic
 name: valkyrie
-version: 2.6.4
+version: 2.6.5
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/valkyrie

--- a/charts/valkyrie/README.md
+++ b/charts/valkyrie/README.md
@@ -1,6 +1,6 @@
 # valkyrie
 
-![Version: 2.6.4](https://img.shields.io/badge/Version-2.6.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 2.6.5](https://img.shields.io/badge/Version-2.6.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Validates data from raw topic and writes it to validated topic
 

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: A custom chart for the vault secrets engine in support of the UrbanOS platform.
 name: vault
-version: 1.3.3
+version: 1.3.4
 sources:
   - https://github.com/hashicorp/vault

--- a/charts/vault/README.md
+++ b/charts/vault/README.md
@@ -1,6 +1,6 @@
 # vault
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A custom chart for the vault secrets engine in support of the UrbanOS platform.
 


### PR DESCRIPTION
## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
