### PR TITLE
Fix andi charts

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.5
+version: 2.2.6
 sources:
 - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.5](https://img.shields.io/badge/Version-2.2.5-informational?style=flat-square)
+![Version: 2.2.6](https://img.shields.io/badge/Version-2.2.6-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -113,13 +113,13 @@ spec:
                 name: {{ .Release.Name }}-andi-aws-credentials
                 key: aws_access_key_secret
           - name: ANDI_LOGO_URL
-            value: "{{  .Values.theme.logo }}"
+            value: '{{  .Values.theme.logo }}'
           - name: ANDI_HEADER_TEXT
-            value: "{{  .Values.theme.headerText }}"
+            value: '{{  .Values.theme.headerText }}'
           - name: ANDI_FOOTER_LEFT_SIDE_TEXT
-            value: "{{  .Values.footer.leftSideText }}"
+            value: '{{  .Values.footer.leftSideText }}'
           - name: ANDI_FOOTER_LINKS
-            value: "{{  .Values.footer.links }}"
+            value: '{{  .Values.footer.links }}'
           {{ if .Values.aws.s3HostName }}
           - name: S3_HOST_NAME
             value: {{ .Values.aws.s3HostName }}

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.2
 - name: andi
   repository: file://../andi
-  version: 2.2.5
+  version: 2.2.6
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.3
@@ -50,5 +50,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.4
-digest: sha256:137b88dced56328751fb0e9dd6a5054021968c48368b508c59131ba21739796b
-generated: "2022-09-27T14:13:01.394264-05:00"
+digest: sha256:f8cba6e40412a9636f7ed19dd4fc74c14e7ff29e14183f5cf86b3f461089396b
+generated: "2022-09-28T13:09:35.179679-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.9
+version: 1.12.10
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.9](https://img.shields.io/badge/Version-1.12.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.10](https://img.shields.io/badge/Version-1.12.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.8](https://img.shields.io/badge/Version-1.12.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.9](https://img.shields.io/badge/Version-1.12.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
