### PR TITLE
837 configurable logo

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.0
+version: 1.4.1
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -30,7 +30,7 @@ A helm chart for the discovery ui
 | global.ingress.dnsZone | string | `"localhost"` |  |
 | global.ingress.rootDnsZone | string | `"localhost"` |  |
 | image.environment | string | `"local"` |  |
-| image.name | string | `"smartcolumbusos/discovery_ui"` |  |
+| image.name | string | `"smartcitiesdata/discovery_ui"` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.tag | string | `"development"` |  |
 | ingress.annotations | string | `nil` |  |

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -25,7 +25,7 @@ data:
     add_header X-Frame-Options "DENY";
     add_header Cache-Control "no-cache, no-store, must-revalidate";
     add_header Pragma "no-cache";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' *.smartcolumbusos.com {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
 
     server_tokens off;

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -11,7 +11,7 @@ service:
   port: 80
 
 image:
-  name: smartcolumbusos/discovery_ui
+  name: smartcitiesdata/discovery_ui
   tag: development
   environment: "local"
   pullPolicy: Always

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.3
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.3.1
+  version: 1.4.1
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -50,5 +50,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:a65fdc4195e5a6e4dd6b433a2cf75e8992c63971cb95ed34f27050ab12501262
-generated: "2022-10-01T16:58:40.029809-06:00"
+digest: sha256:d90a7c405e7c55ebfe50b352caa884848256e09658b57cfc100f3709dc3365b5
+generated: "2022-10-03T13:08:15.355343-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.12
+version: 1.12.13
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- ~~[ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)~~
- ~~[ ] Do you have git hooks installed? (See README.md to install)~~
- ~~[ ] If references to external charts were added:~~
  - ~~[ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - ~~[ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
