### PR TITLE
Us 833

### DIFF
--- a/charts/external-services/README.md
+++ b/charts/external-services/README.md
@@ -1,6 +1,6 @@
 # external-services
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for external services. This is an optional abstraction layer for external dependencies such as redis.
 
@@ -8,6 +8,7 @@ Helm chart for external services. This is an optional abstraction layer for exte
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| enabled | bool | `true` |  |
 | services[0].hostname | string | `"redis.example.com"` |  |
 | services[0].name | string | `"redis"` |  |
 | services[1].hostname | string | `"ldap.example.com"` |  |

--- a/charts/kafka/Chart.lock
+++ b/charts/kafka/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: strimzi-kafka-operator
+  repository: http://strimzi.io/charts/
+  version: 0.31.1
+digest: sha256:d490e1670d0884a6419573fac6051c10b1cb367ece53939db2d55a3f244ffb29
+generated: "2022-10-06T17:08:30.02033-06:00"

--- a/charts/kafka/Chart.lock
+++ b/charts/kafka/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: http://strimzi.io/charts/
   version: 0.31.1
 digest: sha256:d490e1670d0884a6419573fac6051c10b1cb367ece53939db2d55a3f244ffb29
-generated: "2022-10-06T17:08:30.02033-06:00"
+generated: "2022-10-10T08:18:23.281276-06:00"

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.1.10
+version: 1.2.10
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -8,6 +8,6 @@ sources:
   - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.23.0
+    version: 0.31.1
     repository: http://strimzi.io/charts/
     condition: strimzi-kafka-operator.enabled

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 
@@ -8,6 +8,12 @@ A Helm chart for deploying kafka via strimzi
 
 * <https://github.com/strimzi/strimzi-kafka-operator>
 * <https://github.com/apache/kafka>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.31.1 |
 
 ## Values
 
@@ -29,6 +35,7 @@ A Helm chart for deploying kafka via strimzi
 | limitRange.enabled | bool | `true` |  |
 | rbac.enabled | bool | `true` |  |
 | resizeHook.enabled | bool | `true` |  |
+| strimzi-kafka-operator.enabled | bool | `true` |  |
 | strimzi-kafka-operator.resources.limits.cpu | string | `"500m"` |  |
 | strimzi-kafka-operator.resources.requests.cpu | string | `"100m"` |  |
 | tlsSidecar.resources.limits.cpu | string | `"100m"` |  |

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.12
 - name: kafka
   repository: file://../kafka
-  version: 1.1.10
+  version: 1.2.10
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.3
@@ -50,5 +50,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:99283b49be5abe607d54c3fda300b7a640c2aaf775bef5cfcfd603a5c1d17edf
-generated: "2022-10-05T09:18:03.153851-06:00"
+digest: sha256:c5ca405aa3a7ad2959c9dbfb8588bfc159cc1a031d0abe5e87c0494f08dd5e69
+generated: "2022-10-10T08:18:40.554484-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 appVersion: "1.0"
-description: Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
+description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.16
+version: 1.12.17
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,8 +1,8 @@
 # urban-os
 
-![Version: 1.12.14](https://img.shields.io/badge/Version-1.12.14-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.17](https://img.shields.io/badge/Version-1.12.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
-Master chart that deploys the urban os platform. See the individual dependency readmes for configuration options.
+Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
 ## Requirements
 


### PR DESCRIPTION


## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If references to external charts were added:
  - [x] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [x] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
