### PR TITLE
Update DiscoveryUI Configmap to mount at the proper location

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,11 @@
+## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})
+
+Remove if not applicable
+
+## Description
+
+What was changed
+
 ## Reminders
 
 - [ ] Did you up the relevant chart version numbers? (If appropriate)

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.2
+version: 1.4.3
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -21,7 +21,7 @@ A helm chart for the discovery ui
 | env.auth0_domain | string | `""` |  |
 | env.base_url | string | `"example.com"` |  |
 | env.footer_left_side_text | string | `"© 2022 UrbanOS. All rights reserved."` |  |
-| env.footer_links | string | `"[]"` |  |
+| env.footer_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | env.gtm_id | string | `"GTM-EXAMPLE"` |  |
 | env.header_title | string | `"UrbanOS Data Discovery"` |  |
 | env.logo_url | string | `nil` |  |

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -15,32 +15,7 @@ data:
     window.LOGO_URL = '{{.Values.env.logo_url}}'
     window.FOOTER_LEFT_SIDE_TEXT = '{{.Values.env.footer_left_side_text}}'
     window.FOOTER_LINKS = '{{.Values.env.footer_links}}'
+    window.HEADER_TITLE = '{{.Values.env.header_title}}'
     window.AUTH0_DOMAIN = '{{.Values.global.auth.auth0_domain}}'
     window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
-  default.conf: |
-    server_name  localhost;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Frame-Options "DENY";
-    add_header Cache-Control "no-cache, no-store, must-revalidate";
-    add_header Pragma "no-cache";
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' {{ .Values.env.additional_csp_hosts }} *.amazonaws.com *.mapbox.com *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly; worker-src blob:; block-all-mixed-content";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-
-    server_tokens off;
-
-    gzip on;
-    gzip_static on;
-    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-    gzip_proxied  any;
-    gzip_vary on;
-    gzip_comp_level 6;
-    gzip_buffers 16 8k;
-    gzip_http_version 1.1;
-
-    index  index.html index.htm;
-
-    location / {
-      try_files $uri $uri/ /index.html;
-    }

--- a/charts/discovery-ui/templates/deployment.yaml
+++ b/charts/discovery-ui/templates/deployment.yaml
@@ -17,21 +17,18 @@ spec:
     spec:
       imagePullSecrets:
       - name: regcred
+      volumes:
+      - name: discovery-ui-configs
+        configMap:
+          name: discovery-ui-configs
       containers:
       - name: discovery-ui
         image: {{ .Values.image.name }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
-        - mountPath: /opt/app-root/src/config.js
+        - mountPath: /usr/share/nginx/html/config.js
           name: discovery-ui-configs
           subPath: config.js
-        - mountPath: /opt/app-root/etc/nginx.default.d/default.conf
-          name: discovery-ui-configs
-          subPath: default.conf
-      volumes:
-      - name: discovery-ui-configs
-        configMap:
-          name: discovery-ui-configs
 {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -25,7 +25,7 @@ env:
   logo_url: null
   header_title: "UrbanOS Data Discovery"
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
-  footer_links: "[]"
+  footer_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
   mapbox_access_token: ""
   auth0_domain: ""
   auth0_client_id: ""

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.3
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.4.2
+  version: 1.4.3
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.17
+version: 1.12.18
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.17](https://img.shields.io/badge/Version-1.12.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.18](https://img.shields.io/badge/Version-1.12.18-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Description:

- DiscoveryUI Config Map is now mounted to the proper location for nginx to utilize, so the default config.js for local development will be correctly overridden by chart values
- Missing configmap wiring for Header title is now included
- Remove stale nginx conf that was not in use
- Added a single example footer link as the default

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] ~~If references to external charts were added~~:
  - [ ] ~~Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - [ ] ~~Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
