### PR TITLE
838: add primary color to discovery ui chart

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.3
+version: 1.4.4
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -26,6 +26,7 @@ A helm chart for the discovery ui
 | env.header_title | string | `"UrbanOS Data Discovery"` |  |
 | env.logo_url | string | `nil` |  |
 | env.mapbox_access_token | string | `""` |  |
+| env.primary_color | string | `"#1890ff"` |  |
 | env.streets_tile_layer_url | string | `"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.ingress.dnsZone | string | `"localhost"` |  |

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -19,3 +19,4 @@ data:
     window.AUTH0_DOMAIN = '{{.Values.global.auth.auth0_domain}}'
     window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
+    window.PRIMARY_COLOR = '{{.Values.env.primary_color}}'

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -26,6 +26,7 @@ env:
   header_title: "UrbanOS Data Discovery"
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
   footer_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
+  primary_color: '#1890ff'
   mapbox_access_token: ""
   auth0_domain: ""
   auth0_client_id: ""


### PR DESCRIPTION
## [Ticket Link #838](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/838)

## Description

Add env variable for primary color in discovery ui

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If references to external charts were added:
  - [x] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [x] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
