### PR TITLE
helm dependency update - 838

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.3
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.4.3
+  version: 1.4.4
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -50,5 +50,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:d1415e7e5bcb138b9310fff6e6cdf68eb081fd196529bfa49ca628997f3c9cb7
-generated: "2022-10-10T08:44:39.879903-06:00"
+digest: sha256:dbdfa554922a22941a3f79a142d108a02493191d76948a87784f0a432fd46505
+generated: "2022-10-10T12:14:38.105209-05:00"


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
