### PR TITLE
added DISC_UI_URL to discovery_ui

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.4
+version: 1.4.5
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -20,6 +20,7 @@ A helm chart for the discovery ui
 | env.auth0_client_id | string | `""` |  |
 | env.auth0_domain | string | `""` |  |
 | env.base_url | string | `"example.com"` |  |
+| env.disc_ui_url | string | `"example.com"` |  |
 | env.footer_left_side_text | string | `"© 2022 UrbanOS. All rights reserved."` |  |
 | env.footer_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | env.gtm_id | string | `"GTM-EXAMPLE"` |  |

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -20,7 +20,10 @@ env:
   api_host: "https://data.example.com"
   #contribute_host: "https://sharedata.example.com" #Optional location for an associated public Andi deployment
   gtm_id: "GTM-EXAMPLE"
+  #used in react_discovery_ui for websocket command
   base_url: "example.com"
+  #used in discovery_ui for header purposes
+  disc_ui_url: "example.com"
   streets_tile_layer_url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   logo_url: null
   header_title: "UrbanOS Data Discovery"

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -20,9 +20,11 @@ env:
   api_host: "https://data.example.com"
   #contribute_host: "https://sharedata.example.com" #Optional location for an associated public Andi deployment
   gtm_id: "GTM-EXAMPLE"
-  #used in react_discovery_ui for websocket command
+  # the host domain where urbanos is deployed
+  # used in react_discovery_ui for websocket command
   base_url: "example.com"
-  #used in discovery_ui for header purposes
+  # the domain where discovery ui will be deployed
+  # used in discovery_ui for header purposes
   disc_ui_url: "example.com"
   streets_tile_layer_url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   logo_url: null

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.3
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.4.4
+  version: 1.4.5
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -50,5 +50,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:dbdfa554922a22941a3f79a142d108a02493191d76948a87784f0a432fd46505
-generated: "2022-10-10T12:14:38.105209-05:00"
+digest: sha256:2555c0b058fd24875afdcd65a369c2b5cbe450d7a0b0c2b2068bcc210c4059f4
+generated: "2022-10-10T13:07:26.369048-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.20
+version: 1.12.21
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template` pass?)
~~- [] Do you have git hooks installed? (See README.md to install)~~
~~- [] If references to external charts were added:~~
  ~~- [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  ~~- [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
