### PR TITLE
Changing footer defaults for Andi

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.10
+version: 2.2.11
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -98,8 +98,8 @@ theme:
 
 footer:
   # footer text on left side with links on right side
-  leftSideText: "Some Left Side Text"
-  links: '[{"linkText":"Example 1", "url":"https://www.example.com"}, {"linkText":"Example 2", "url":"https://www.google.com"}]'
+  leftSideText: "© 2022 UrbanOS. All rights reserved."
+  links: '[{"linkText":"Discovery UI", "url":"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/"}, {"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
 
 tolerations:
   - key: example.run.public-worker

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.2.10
+  version: 2.2.11
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:b5d9cb4908a4977230387ef90268dee626946ba18248c1e9ea6c08adc69ddb4c
-generated: "2022-10-11T14:06:33.635263-05:00"
+digest: sha256:9f2a7d9b5f678bc2f633baa73f043be63690d360483c15ae3d54cc23cc66b922
+generated: "2022-10-13T12:05:12.342044-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.23
+version: 1.12.24
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## Description

Changing Andi defaults to be more standardized, non-test text.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
~- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)~
- [x] Do you have git hooks installed? (See README.md to install)
~- [ ] If references to external charts were added:~
  ~- [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?~
  ~- [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~
