### PR TITLE
Bumping kafka to release

### DIFF
--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.10](https://img.shields.io/badge/Version-2.2.10-informational?style=flat-square)
+![Version: 2.2.11](https://img.shields.io/badge/Version-2.2.11-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 
@@ -20,8 +20,8 @@ REST API to allow for dataset definition ingestion
 | aws.s3HostName | string | `nil` |  |
 | aws.s3Port | string | `nil` |  |
 | documentationRoot | string | `""` |  |
-| footer.leftSideText | string | `"Some Left Side Text"` |  |
-| footer.links | string | `"[{\"linkText\":\"Example 1\", \"url\":\"https://www.example.com\"}, {\"linkText\":\"Example 2\", \"url\":\"https://www.google.com\"}]"` |  |
+| footer.leftSideText | string | `"© 2022 UrbanOS. All rights reserved."` |  |
+| footer.links | string | `"[{\"linkText\":\"Discovery UI\", \"url\":\"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/\"}, {\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | fullnameOverride | string | `""` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.auth.jwt_issuer | string | `""` |  |

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.10
+version: 1.2.11
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.10](https://img.shields.io/badge/Version-1.2.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.11](https://img.shields.io/badge/Version-1.2.11-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.13
 - name: kafka
   repository: file://../kafka
-  version: 1.2.10
+  version: 1.2.11
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.3
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:9f2a7d9b5f678bc2f633baa73f043be63690d360483c15ae3d54cc23cc66b922
-generated: "2022-10-13T12:05:12.342044-04:00"
+digest: sha256:45cf6e412bf43e2b44f0a71b65f2297016b26429c7eb24c1ef8dec362ef7b570
+generated: "2022-10-13T17:58:53.363041-04:00"

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.23](https://img.shields.io/badge/Version-1.12.23-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.24](https://img.shields.io/badge/Version-1.12.24-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Description

Bumping kafka version because its trying to be released for some reason.

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
