### PR TITLE
Andi AWS secret optional to allow for pre-created secrets

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.11
+version: 2.2.12
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.12
+version: 2.2.13
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.12](https://img.shields.io/badge/Version-2.2.12-informational?style=flat-square)
+![Version: 2.2.13](https://img.shields.io/badge/Version-2.2.13-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.10](https://img.shields.io/badge/Version-2.2.10-informational?style=flat-square)
+![Version: 2.2.12](https://img.shields.io/badge/Version-2.2.12-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 
@@ -20,8 +20,8 @@ REST API to allow for dataset definition ingestion
 | aws.s3HostName | string | `nil` |  |
 | aws.s3Port | string | `nil` |  |
 | documentationRoot | string | `""` |  |
-| footer.leftSideText | string | `"Some Left Side Text"` |  |
-| footer.links | string | `"[{\"linkText\":\"Example 1\", \"url\":\"https://www.example.com\"}, {\"linkText\":\"Example 2\", \"url\":\"https://www.google.com\"}]"` |  |
+| footer.leftSideText | string | `"© 2022 UrbanOS. All rights reserved."` |  |
+| footer.links | string | `"[{\"linkText\":\"Discovery UI\", \"url\":\"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/\"}, {\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | fullnameOverride | string | `""` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.auth.jwt_issuer | string | `""` |  |

--- a/charts/andi/templates/secrets.yaml
+++ b/charts/andi/templates/secrets.yaml
@@ -19,11 +19,13 @@ stringData:
   auth0_client_secret: {{ quote .Values.auth.auth0_client_secret }}
 {{- end }}
 ---
+{{- if or (.Values.aws.accessKeyId) (.Values.global.objectStore.accessKey) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-andi-aws-credentials
 type: Opaque
 stringData:
-  aws_access_key_secret: {{ .Values.global.objectStore.accessSecret | default .Values.aws.accessKeySecret | quote }}
   aws_access_key_id: {{ .Values.global.objectStore.accessKey | default .Values.aws.accessKeyId | quote}}
+  aws_access_key_secret: {{ .Values.global.objectStore.accessSecret | default .Values.aws.accessKeySecret | quote }}
+{{- end }}

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -69,14 +69,21 @@ postgres:
 auth:
   auth0_client_id: ""
   # if left empty, no secret will be created
-  # and {{ .Release.Name }}-raptor-auth0-client-secret will be referenced
+  # and {{ .Release.Name }}-andi-auth0-client-secret will be referenced
   auth0_client_secret: ""
 
 aws:
+  #################
+  # If these are left empty, no secret will be created.
+  # An existing {{ .Release.Name }}-andi-aws-credentials secret will be
+  #   referenced instead of utilizing accessKeyId and accessKeySecret to create
+  #   a secret.
+  #################
   # Overriden by global.objectStore.accessKey if present
   accessKeyId: ""
   # Overriden by global.objectStore.accessSecret if present
   accessKeySecret: ""
+  #################
   s3HostName: null
   s3Port: null
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.2.12
+  version: 2.2.13
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:7b67350aad60081edfb1ef1cedb8ec6d9033462843178320073684f9cb00a060
-generated: "2022-10-14T11:26:01.125543-04:00"
+digest: sha256:47f8f6369c10478cea2d73c696e0d46f586940f8a1a0a9fe0c760ded667440db
+generated: "2022-10-14T09:41:24.092183-06:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:45cf6e412bf43e2b44f0a71b65f2297016b26429c7eb24c1ef8dec362ef7b570
-generated: "2022-10-13T17:58:53.363041-04:00"
+digest: sha256:1c52f0ec433133f21b95bc0e574b94fffea98ecdd99d06f97d7375db10b08717
+generated: "2022-10-14T08:20:50.667688-06:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.2.11
+  version: 2.2.12
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:9f2a7d9b5f678bc2f633baa73f043be63690d360483c15ae3d54cc23cc66b922
-generated: "2022-10-13T12:05:12.342044-04:00"
+digest: sha256:e74b863d6c9eb676460dc7e534ce016a401966b3bdd2958dea82a0a864fa78bb
+generated: "2022-10-13T20:16:54.487214-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.24
+version: 1.12.25
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.26
+version: 1.12.27
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.26](https://img.shields.io/badge/Version-1.12.26-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.27](https://img.shields.io/badge/Version-1.12.27-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.23](https://img.shields.io/badge/Version-1.12.23-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.25](https://img.shields.io/badge/Version-1.12.25-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
Ticket Link NA

## Description

- Similar to the existing functionality where the auth0 secret can optionally be managed / created by helm, this adds that functionality to the aws secrets that andi utilizes.
- Corrected raptor to andi in an andi comment

Confirmed with a helm diff that this will not have effects on the product environment

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] ~~If references to external charts were added:~~
  - [ ] ~~Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - [ ] ~~Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
