### PR TITLE
added footer_left_side_link to discoveryUI and ANDI

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.14
+version: 2.3.0
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.2.13
+version: 2.2.14
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.14](https://img.shields.io/badge/Version-2.2.14-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -22,7 +22,7 @@ REST API to allow for dataset definition ingestion
 | documentationRoot | string | `""` |  |
 | footer.leftSideLink | string | `"https://github.com/UrbanOS-Public/smartcitiesdata"` |  |
 | footer.leftSideText | string | `"© 2022 UrbanOS. All rights reserved."` |  |
-| footer.links | string | `"[{\"linkText\":\"Discovery UI\", \"url\":\"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/\"}, {\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
+| footer.rightLinks | string | `"[{\"linkText\":\"Discovery UI\", \"url\":\"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/\"}, {\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | fullnameOverride | string | `""` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.auth.jwt_issuer | string | `""` |  |

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.2.13](https://img.shields.io/badge/Version-2.2.13-informational?style=flat-square)
+![Version: 2.2.14](https://img.shields.io/badge/Version-2.2.14-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 
@@ -20,6 +20,7 @@ REST API to allow for dataset definition ingestion
 | aws.s3HostName | string | `nil` |  |
 | aws.s3Port | string | `nil` |  |
 | documentationRoot | string | `""` |  |
+| footer.leftSideLink | string | `"https://github.com/UrbanOS-Public/smartcitiesdata"` |  |
 | footer.leftSideText | string | `"© 2022 UrbanOS. All rights reserved."` |  |
 | footer.links | string | `"[{\"linkText\":\"Discovery UI\", \"url\":\"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/\"}, {\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -138,6 +138,8 @@ spec:
             value: '{{  .Values.theme.primaryColor }}'
           - name: ANDI_FOOTER_LEFT_SIDE_TEXT
             value: '{{  .Values.footer.leftSideText }}'
+          - name: ANDI_FOOTER_LEFT_SIDE_LINK
+            value: '{{  .Values.footer.leftSideLink }}'
           - name: ANDI_FOOTER_LINKS
             value: '{{  .Values.footer.links }}'
           {{ if .Values.aws.s3HostName }}

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -140,8 +140,8 @@ spec:
             value: '{{  .Values.footer.leftSideText }}'
           - name: ANDI_FOOTER_LEFT_SIDE_LINK
             value: '{{  .Values.footer.leftSideLink }}'
-          - name: ANDI_FOOTER_LINKS
-            value: '{{  .Values.footer.links }}'
+          - name: ANDI_FOOTER_RIGHT_LINKS
+            value: '{{  .Values.footer.rightLinks }}'
           {{ if .Values.aws.s3HostName }}
           - name: S3_HOST_NAME
             value: {{ .Values.aws.s3HostName }}

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -107,7 +107,7 @@ footer:
   # footer text on left side with links on right side
   leftSideText: "© 2022 UrbanOS. All rights reserved."
   leftSideLink: "https://github.com/UrbanOS-Public/smartcitiesdata"
-  links: '[{"linkText":"Discovery UI", "url":"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/"}, {"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
+  rightLinks: '[{"linkText":"Discovery UI", "url":"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/"}, {"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
 
 tolerations:
   - key: example.run.public-worker

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -106,6 +106,7 @@ theme:
 footer:
   # footer text on left side with links on right side
   leftSideText: "© 2022 UrbanOS. All rights reserved."
+  leftSideLink: "https://github.com/UrbanOS-Public/smartcitiesdata"
   links: '[{"linkText":"Discovery UI", "url":"https://discovery.dev.apps.hsrqs9l3.eastus.aroapp.io/"}, {"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
 
 tolerations:

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.7
+version: 1.5.0
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.4.6
+version: 1.4.7
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.4.7](https://img.shields.io/badge/Version-1.4.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.4.6](https://img.shields.io/badge/Version-1.4.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.4.7](https://img.shields.io/badge/Version-1.4.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -21,6 +21,7 @@ A helm chart for the discovery ui
 | env.auth0_domain | string | `""` |  |
 | env.base_url | string | `"example.com"` |  |
 | env.disc_ui_url | string | `"example.com"` |  |
+| env.footer_left_side_link | string | `"https://github.com/UrbanOS-Public/smartcitiesdata"` |  |
 | env.footer_left_side_text | string | `"© 2022 UrbanOS. All rights reserved."` |  |
 | env.footer_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | env.gtm_id | string | `"GTM-EXAMPLE"` |  |

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -23,7 +23,7 @@ A helm chart for the discovery ui
 | env.disc_ui_url | string | `"example.com"` |  |
 | env.footer_left_side_link | string | `"https://github.com/UrbanOS-Public/smartcitiesdata"` |  |
 | env.footer_left_side_text | string | `"© 2022 UrbanOS. All rights reserved."` |  |
-| env.footer_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
+| env.footer_right_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |
 | env.gtm_id | string | `"GTM-EXAMPLE"` |  |
 | env.header_title | string | `"UrbanOS Data Discovery"` |  |
 | env.logo_url | string | `nil` |  |

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -16,7 +16,7 @@ data:
     window.LOGO_URL = '{{.Values.env.logo_url}}'
     window.FOOTER_LEFT_SIDE_TEXT = '{{.Values.env.footer_left_side_text}}'
     window.FOOTER_LEFT_SIDE_LINK = '{{.Values.env.footer_left_side_link}}'
-    window.FOOTER_LINKS = '{{.Values.env.footer_links}}'
+    window.FOOTER_RIGHT_LINKS = '{{.Values.env.footer_right_links}}'
     window.HEADER_TITLE = '{{.Values.env.header_title}}'
     window.AUTH0_DOMAIN = '{{.Values.global.auth.auth0_domain}}'
     window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -15,6 +15,7 @@ data:
     window.MAPBOX_ACCESS_TOKEN = '{{.Values.env.mapbox_access_token}}'
     window.LOGO_URL = '{{.Values.env.logo_url}}'
     window.FOOTER_LEFT_SIDE_TEXT = '{{.Values.env.footer_left_side_text}}'
+    window.FOOTER_LEFT_SIDE_LINK = '{{.Values.env.footer_left_side_link}}'
     window.FOOTER_LINKS = '{{.Values.env.footer_links}}'
     window.HEADER_TITLE = '{{.Values.env.header_title}}'
     window.AUTH0_DOMAIN = '{{.Values.global.auth.auth0_domain}}'

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -31,7 +31,7 @@ env:
   header_title: "UrbanOS Data Discovery"
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
   footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
-  footer_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
+  footer_right_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
   primary_color: '#1890ff'
   mapbox_access_token: ""
   auth0_domain: ""

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -30,6 +30,7 @@ env:
   logo_url: null
   header_title: "UrbanOS Data Discovery"
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
+  footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
   footer_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
   primary_color: '#1890ff'
   mapbox_access_token: ""

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.2.14
+  version: 2.3.0
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.4
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.4.7
+  version: 1.5.0
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:ae9b8f58d88123aee0c3ce4ea4cd9b39bbbcf75f6253c56c4de4ef7256cb1a98
-generated: "2022-10-17T14:08:29.601403-05:00"
+digest: sha256:b1f2a2e2870cb9d803c5fdc705ae74cde71934d735c22a9a41f4a69e1107c35d
+generated: "2022-10-17T14:38:21.178167-05:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.2.13
+  version: 2.2.14
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.4
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.4.6
+  version: 1.4.7
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:47f8f6369c10478cea2d73c696e0d46f586940f8a1a0a9fe0c760ded667440db
-generated: "2022-10-14T09:41:24.092183-06:00"
+digest: sha256:ae9b8f58d88123aee0c3ce4ea4cd9b39bbbcf75f6253c56c4de4ef7256cb1a98
+generated: "2022-10-17T14:08:29.601403-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.27
+version: 1.12.28
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.12.28
+version: 1.13.0
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.27](https://img.shields.io/badge/Version-1.12.27-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.12.28](https://img.shields.io/badge/Version-1.12.28-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.12.28](https://img.shields.io/badge/Version-1.12.28-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
~~- [ ] Do you have git hooks installed? (See README.md to install)~~
~~- [ ] If references to external charts were added:~~
  ~~- [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  ~~- [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
