### PR TITLE
Correct flipped secret + key

### DIFF
--- a/charts/sauron/Chart.yaml
+++ b/charts/sauron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 name: sauron
-version: 0.0.7
+version: 0.0.8

--- a/charts/sauron/README.md
+++ b/charts/sauron/README.md
@@ -1,6 +1,6 @@
 # sauron
 
-![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 

--- a/charts/sauron/templates/sauron-commands.yaml
+++ b/charts/sauron/templates/sauron-commands.yaml
@@ -225,8 +225,8 @@ data:
         cat << EOT > secrets.yaml
     global:
       objectStore:
-        accessSecret: "{{ if .Values.global.objectStore.accessKey }}$GLOBAL_OBJECTSTORE_ACCESSKEY{{ end }}" 
-        accessKey: "{{ if .Values.global.objectStore.accessSecret }}$GLOBAL_OBJECTSTORE_ACCESSSECRET{{ end }}"
+        accessKey: "{{ if .Values.global.objectStore.accessKey }}$GLOBAL_OBJECTSTORE_ACCESSKEY{{ end }}"
+        accessSecret: "{{ if .Values.global.objectStore.accessSecret }}$GLOBAL_OBJECTSTORE_ACCESSSECRET{{ end }}" 
     andi:
       auth:
         auth0_client_secret: "{{ if .Values.remoteDeployment.secrets.andi.auth.auth0_client_secret }}$ANDI_AUTH0_CLIENT_SECRET{{ end }}"


### PR DESCRIPTION
Ticket: NA

## Description

Fixed typo in sauron chart so that object key and secret aren't flipped

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] ~~If you up a chart version within urban-os, have you also upped the urban-os chart version itself?~~
  - [ ] ~~If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?~~
- [ ] ~~If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)~~
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] ~~If references to external charts were added:~~
  - [ ] ~~Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
