### PR TITLE
Persistence Chart: align default values with what's in templates

### DIFF
--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v1
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.2
+version: 1.0.3
 dependencies:
   - name: trino
     version: 0.8.0

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 
@@ -8,12 +8,12 @@ Data persistence for UrbanOS using Trino and the Hive Metastore
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| global.s3.accessKey | string | `"example"` |  |
-| global.s3.hiveStorageBucket | string | `"hive-storage"` |  |
-| global.s3.hiveStoragePath | string | `nil` |  |
-| global.s3.host | string | `"example.com"` |  |
-| global.s3.port | int | `8000` |  |
-| global.s3.secretKey | string | `"example"` |  |
+| global.objectStore.accessKey | string | `"example-key"` |  |
+| global.objectStore.hiveStorageBucket | string | `"presto-hive-storage"` |  |
+| global.objectStore.hiveStoragePath | string | `"hive-s3"` |  |
+| global.objectStore.host | string | `"minio"` |  |
+| global.objectStore.port | int | `80` |  |
+| global.objectStore.secretKey | string | `"example-secret"` |  |
 | metastore.image.repository | string | `"quay.io/cloudservices/ubi-hive"` |  |
 | metastore.image.tag | string | `"3.1.2-metastore-009"` |  |
 | metastore.postgres.host | string | `"postgres"` |  |

--- a/charts/persistence/values.yaml
+++ b/charts/persistence/values.yaml
@@ -1,11 +1,11 @@
 global:
-  s3:
-    host: example.com
-    port: 8000
-    accessKey: example
-    secretKey: example
-    hiveStorageBucket: hive-storage
-    hiveStoragePath:
+  objectStore:
+    host: minio
+    port: 80
+    accessKey: example-key
+    secretKey: example-secret
+    hiveStorageBucket: presto-hive-storage
+    hiveStoragePath: hive-s3
 
 metastore:
   image:

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 1.7.3
 - name: persistence
   repository: file://../persistence
-  version: 1.0.2
+  version: 1.0.3
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.1
@@ -47,5 +47,5 @@ dependencies:
 - name: vault
   repository: file://../vault
   version: 1.3.5
-digest: sha256:b1f2a2e2870cb9d803c5fdc705ae74cde71934d735c22a9a41f4a69e1107c35d
-generated: "2022-10-17T14:38:21.178167-05:00"
+digest: sha256:7a3f2a6c5d3b583ccc4e01d3ec11e7130892db2c7297626ab82d1b4217446f90
+generated: "2022-10-19T21:12:05.616488-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.0
+version: 1.13.1
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.0](https://img.shields.io/badge/Version-1.13.0-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.1](https://img.shields.io/badge/Version-1.13.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
NA Ticket

## Description

The default values for global.s3 are now included, instead of the previously useless values. This is a much better default as hive deployment was entirely missing configuration values by default.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] ~~If references to external charts were added:~~
  - [ ] ~~Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - [ ] ~~Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
