### PR TITLE
Added hashicorp as a dependency for vault chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
           helm repo add strimzi http://strimzi.io/charts/
           helm repo add trinodb https://trinodb.github.io/charts/
           helm repo add operator https://operator.min.io/
+          helm repo add hashicorp https://helm.releases.hashicorp.com
           helm repo update
           helm dependency update charts/kafka
           helm dependency update charts/persistence


### PR DESCRIPTION
## Description

Added hashicorp as a dependency for vault chart

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
