### PR TITLE
Bumped tangled versions

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.0
+version: 2.3.1
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v2
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.4
+version: 1.0.5
 sources:
   - https://github.com/trinodb/trino
   - https://github.com/minio/operator

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 name: reaper
-version: 1.2.7
+version: 1.2.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/reaper

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -1,6 +1,6 @@
 # reaper
 
-![Version: 1.2.7](https://img.shields.io/badge/Version-1.2.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.0
+  version: 2.3.1
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.5
@@ -31,7 +31,7 @@ dependencies:
   version: 1.7.3
 - name: persistence
   repository: file://../persistence
-  version: 1.0.4
+  version: 1.0.5
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.1
@@ -40,12 +40,12 @@ dependencies:
   version: 1.1.7
 - name: reaper
   repository: file://../reaper
-  version: 1.2.7
+  version: 1.2.8
 - name: valkyrie
   repository: file://../valkyrie
   version: 2.6.7
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.22.0
-digest: sha256:a21bb35c345c78f153e33531a0859687f56e82d2a03790b9b8ef774195ac2934
-generated: "2022-10-24T19:43:57.601153-04:00"
+digest: sha256:3e7866bd62c2bfcade812ca1318713123552b563917293b892835ac71f3a1be6
+generated: "2022-10-25T09:49:36.161928-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.4
+version: 1.13.5
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.4](https://img.shields.io/badge/Version-1.13.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.5](https://img.shields.io/badge/Version-1.13.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Description

Bumped versions that are not releasing correctly in github actions

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
