### PR TITLE
add minio env vars

### DIFF
--- a/charts/sauron/Chart.yaml
+++ b/charts/sauron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 name: sauron
-version: 0.0.8
+version: 0.0.9

--- a/charts/sauron/templates/cron.yaml
+++ b/charts/sauron/templates/cron.yaml
@@ -82,6 +82,14 @@ spec:
                 {{- if .Values.remoteDeployment.proxyAccountPAT -}}
                 - name: SAURON_PROXY_PAT
                   value: "{{ .Values.remoteDeployment.proxyAccountPAT }}"
+                {{ end -}}
+                {{- if .Values.remoteDeployment.secrets.minio.rootUserName -}}
+                - name: MINIO_ROOT_USERNAME
+                  value: "{{ .Values.remoteDeployment.secrets.minio.rootUserName }}"
+                {{ end -}}
+                {{- if .Values.remoteDeployment.secrets.minio.rootPassword -}}
+                - name: MINIO_ROOT_PASSWORD
+                  value: "{{ .Values.remoteDeployment.secrets.minio.rootPassword }}"
                 {{ end }}
               command:
                 - "/bin/bash"

--- a/charts/sauron/templates/sauron-commands.yaml
+++ b/charts/sauron/templates/sauron-commands.yaml
@@ -245,6 +245,12 @@ data:
     raptor:
       auth:
         auth0_client_secret: "{{ if .Values.remoteDeployment.secrets.raptor.auth.auth0_client_secret }}$RAPTOR_AUTH0_CLIENT_SECRET{{ end }}"
+    secrets:
+      minio: 
+        base64UserAccessKey: "{{ if .Values.global.objectStore.accessKey }}$GLOBAL_OBJECTSTORE_ACCESSKEY{{ end }}"
+        base64UserSecretKey: "{{ if .Values.global.objectStore.accessSecret }}$GLOBAL_OBJECTSTORE_ACCESSSECRET{{ end }}"
+        rootUserName: "{{ if .Values.remoteDeployment.secrets.minio.rootUserName }}$MINIO_ROOT_USERNAME{{ end }}"
+        rootPassword: "{{ if .Values.remoteDeployment.secrets.minio.rootPassword }}$MINIO_ROOT_PASSWORD{{ end }}"
     EOT
         
         echo "Updating sauron state to new deployment SHA"

--- a/charts/sauron/values.yaml
+++ b/charts/sauron/values.yaml
@@ -39,3 +39,9 @@ remoteDeployment:
         guardianSecretKey: ""
       postgres:
         password: ""
+
+    minio:
+      base64UserAccessKey: ""
+      base64UserSecretKey: ""
+      rootUserName: ""
+      rootPassword: ""


### PR DESCRIPTION

## Description

updating minio env vars

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
