### PR TITLE
Discovery UI require login

### DIFF
--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.5
+version: 1.4.6
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/README.md
+++ b/charts/discovery-api/README.md
@@ -1,6 +1,6 @@
 # discovery-api
 
-![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 1.4.6](https://img.shields.io/badge/Version-1.4.6-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 A middleware layer to connect data consumers with the data sources
 
@@ -39,6 +39,7 @@ A middleware layer to connect data consumers with the data sources
 | global.redis.passwordSecret | string | `""` |  |
 | global.redis.port | int | `6379` |  |
 | global.redis.sslEnabled | bool | `false` |  |
+| global.require_api_key | bool | `false` |  |
 | global.vault.endpoint | string | `"vault.vault:8200"` |  |
 | image.majorPin | string | `""` |  |
 | image.minorPin | string | `""` |  |

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
             value: {{ quote .Values.monitoring.targetPort }}
           - name: RAPTOR_URL
             value: {{ quote .Values.global.auth.raptor_url }}
+          - name: REQUIRE_API_KEY
+            value: {{ .Values.global.require_api_key }}
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/charts/discovery-api/values.yaml
+++ b/charts/discovery-api/values.yaml
@@ -10,6 +10,7 @@ global:
     brokers: pipeline-kafka-bootstrap:9092
   presto:
     url: http://platform-kubernetes-data-platform-presto:8080
+  require_api_key: false  
   redis:
     host: redis.external-services
     port: 6379

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.1.4
+version: 1.1.5
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/README.md
+++ b/charts/discovery-streams/README.md
@@ -1,6 +1,6 @@
 # discovery-streams
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Dynamically find kafka topics and makes available corresponding channels on a public websocket
 
@@ -22,6 +22,7 @@ Dynamically find kafka topics and makes available corresponding channels on a pu
 | global.redis.passwordSecret | string | `""` |  |
 | global.redis.port | int | `6379` |  |
 | global.redis.sslEnabled | bool | `false` |  |
+| global.require_api_key | bool | `false` |  |
 | image.majorPin | string | `""` |  |
 | image.minorPin | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |

--- a/charts/discovery-streams/templates/deployment.yaml
+++ b/charts/discovery-streams/templates/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: "true"
         - name: RAPTOR_URL
           value: {{ quote .Values.global.auth.raptor_url }}
+        - name: REQUIRE_API_KEY
+          value: {{ .Values.global.require_api_key }}
         - name: METRICS_PORT
           value: {{ quote .Values.monitoring.targetPort }}
         - name: NAMESPACE

--- a/charts/discovery-streams/values.yaml
+++ b/charts/discovery-streams/values.yaml
@@ -1,6 +1,7 @@
 global:
   kafka:
     brokers: pipeline-kafka-bootstrap:9092
+  require_api_key: false  
   redis:
     host: redis.external-services
     password: ""

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.3
+version: 1.5.4
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -34,6 +34,7 @@ A helm chart for the discovery ui
 | global.auth.auth0_domain | string | `""` |  |
 | global.ingress.dnsZone | string | `"localhost"` |  |
 | global.ingress.rootDnsZone | string | `"localhost"` |  |
+| global.require_api_key | bool | `false` |  |
 | image.environment | string | `"local"` |  |
 | image.name | string | `"smartcitiesdata/discovery_ui"` |  |
 | image.pullPolicy | string | `"Always"` |  |

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -22,5 +22,6 @@ data:
     window.AUTH0_CLIENT_ID = '{{.Values.env.auth0_client_id}}'
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
     window.PRIMARY_COLOR = '{{.Values.env.primary_color}}'
+    window.REQUIRE_API_KEY = '{{.Values.global.require_api_key}}'
   nginx-csps.conf: |
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.amazonaws.com *.mapbox.com {{ .Values.env.additional_csp_hosts }} *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly http://localhost:*; worker-src blob:;";

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -4,6 +4,7 @@ global:
   ingress:
     rootDnsZone: localhost
     dnsZone: localhost
+  require_api_key: false
 
 service:
   name: discovery-ui

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.14](https://img.shields.io/badge/Version-1.2.14-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.16](https://img.shields.io/badge/Version-1.2.16-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -7,13 +7,13 @@ dependencies:
   version: 2.3.1
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.4.5
+  version: 1.4.6
 - name: discovery-streams
   repository: file://../discovery-streams
-  version: 1.1.4
+  version: 1.1.5
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.3
+  version: 1.5.4
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:154a2b16dbf0d617f3ea0794549d3e1e8f296afab0c65b49872333115e573b90
-generated: "2022-11-09T11:33:12.645387-07:00"
+digest: sha256:ba7a4f0d803c26dff0618ac4adc10aa5f42a1ac5ee19319bf78b63897f4d2359
+generated: "2022-11-15T14:31:26.692691-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.11
+version: 1.13.12
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.9](https://img.shields.io/badge/Version-1.13.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.12](https://img.shields.io/badge/Version-1.13.12-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
@@ -53,6 +53,7 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | global.presto.url | string | `"http://kubernetes-data-platform-presto:8080"` | This is the default url that presto is deployed to with the chart. Override this if you are using an external presto cluster. |
 | global.redis.host | string | `"redis.external-services"` | The url to a Redis instance. *Note*: Most apps in the platform require access to a Redis instance, and one is not currently included in the chart. |
 | global.redis.password | string | `""` |  |
+| global.require_api_key | bool | `false` | Determines whether a user is required to log in in order to see public data in the discovery suite |
 | global.vault.endpoint | string | `"vault:8200"` | A url to a vault instance. Reaper and Andi use vault to read and store secrets for dataset ingestion. *Note*: Currently, only the provided vault chart works with UrbanOS |
 | kafka.enabled | bool | `true` |  |
 | kubernetes-data-platform.enabled | bool | `false` |  |

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -15,6 +15,8 @@ global:
   presto:
     # -- This is the default url that presto is deployed to with the chart. Override this if you are using an external presto cluster.
     url: http://kubernetes-data-platform-presto:8080
+  # -- Determines whether a user is required to log in in order to see public data in the discovery suite
+  require_api_key: false
   redis:
     # -- The url to a Redis instance. *Note*: Most apps in the platform require access to a Redis instance, and one is not currently included in the chart.
     host: redis.external-services


### PR DESCRIPTION
## [Ticket Link](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/934)

## Description

Add require_api_key value to charts which will enable/disable users from viewing public datasets without logging in

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [x] Are they also specified in the urbanos chart values file?
- [ ] ~~If references to external charts were added:~~
  - [ ] ~~Was the github release action updated to `helm update {new_thing}` it's dependencies?~~
  - [ ] ~~Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~~
