### PR TITLE
Added conditional to minio secrets

### DIFF
--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.12
+version: 1.13.13
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.12](https://img.shields.io/badge/Version-1.13.12-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.13](https://img.shields.io/badge/Version-1.13.13-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 

--- a/charts/urban-os/templates/minio-secrets.yaml
+++ b/charts/urban-os/templates/minio-secrets.yaml
@@ -1,3 +1,4 @@
+{{- if index .Values "minio-tenant" "enabled" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,3 +19,4 @@ stringData:
   config.env: |-
     export MINIO_ROOT_USER={{ .Values.secrets.minio.rootUserName | quote }}
     export MINIO_ROOT_PASSWORD={{ .Values.secrets.minio.rootPassword | quote }}
+{{- end }}


### PR DESCRIPTION
## Description

Added conditional to minio secrets so they are not generated if minio is disabled

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
