### PR TITLE
Added minio endpoint as a sauron environment variable

### DIFF
--- a/charts/sauron/Chart.yaml
+++ b/charts/sauron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 name: sauron
-version: 0.0.10
+version: 0.0.11

--- a/charts/sauron/README.md
+++ b/charts/sauron/README.md
@@ -1,6 +1,6 @@
 # sauron
 
-![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 
@@ -23,6 +23,7 @@ Cron jobs that watch remote deployments and images, issuing cluster commands as 
 | remoteDeployment.secrets.discovery-api.secrets.guardianSecretKey | string | `""` |  |
 | remoteDeployment.secrets.minio.base64UserAccessKey | string | `""` |  |
 | remoteDeployment.secrets.minio.base64UserSecretKey | string | `""` |  |
+| remoteDeployment.secrets.minio.endpoint | string | `"http://minio:80"` |  |
 | remoteDeployment.secrets.minio.rootPassword | string | `""` |  |
 | remoteDeployment.secrets.minio.rootUserName | string | `""` |  |
 | remoteDeployment.secrets.persistence.metastore.postgres.password | string | `""` |  |

--- a/charts/sauron/templates/cron.yaml
+++ b/charts/sauron/templates/cron.yaml
@@ -83,6 +83,10 @@ spec:
                 - name: SAURON_PROXY_PAT
                   value: "{{ .Values.remoteDeployment.proxyAccountPAT }}"
                 {{ end -}}
+                {{- if .Values.remoteDeployment.secrets.minio.endpoint -}}
+                - name: MINIO_ENDPOINT
+                  value: "{{ .Values.remoteDeployment.secrets.minio.endpoint }}"
+                {{ end -}}
                 {{- if .Values.remoteDeployment.secrets.minio.rootUserName -}}
                 - name: MINIO_ROOT_USERNAME
                   value: "{{ .Values.remoteDeployment.secrets.minio.rootUserName }}"

--- a/charts/sauron/values.yaml
+++ b/charts/sauron/values.yaml
@@ -41,6 +41,8 @@ remoteDeployment:
         password: ""
 
     minio:
+      #This endpoint is only needed in here because we have to apply it post-render via environment variables for the hive-catalog workaround
+      endpoint: "http://minio:80"
       base64UserAccessKey: ""
       base64UserSecretKey: ""
       rootUserName: ""


### PR DESCRIPTION
## Description

Added minio endpoint as a sauron environment variable

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
