### PR TITLE
Adding new environment variables with placeholders

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.5
+version: 1.5.6
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -21,7 +21,9 @@ A helm chart for the discovery ui
 | env.auth0_domain | string | `""` |  |
 | env.base_url | string | `"example.com"` |  |
 | env.contribute_host | string | `""` |  |
-| env.disc_ui_url | string | `"example.com"` |  |
+| env.disc_api_url | string | `"https://data.example.com"` |  |
+| env.disc_streams_url | string | `"https://streams.example.com"` |  |
+| env.disc_ui_url | string | `"https://www.example.com"` |  |
 | env.footer_left_side_link | string | `"https://github.com/UrbanOS-Public/smartcitiesdata"` |  |
 | env.footer_left_side_text | string | `"© 2022 UrbanOS. All rights reserved."` |  |
 | env.footer_right_links | string | `"[{\"linkText\":\"UrbanOS\", \"url\":\"https://github.com/UrbanOS-Public/smartcitiesdata\"}]"` |  |

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -29,7 +29,9 @@ env:
   base_url: "example.com"
   # the domain where discovery ui will be deployed
   # used in discovery_ui for header purposes
-  disc_ui_url: "example.com"
+  disc_ui_url: "https://www.example.com"
+  disc_api_url: "https://data.example.com"
+  disc_streams_url: "https://streams.example.com"
   streets_tile_layer_url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   logo_url: null
   header_title: "UrbanOS Data Discovery"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.5
+  version: 1.5.6
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:092117a2db3f9f42c552f1c2bf9f79612094d334dde24539acde765550df868a
-generated: "2022-11-17T11:38:57.382431-05:00"
+digest: sha256:eeb54ea1806e1553b23406db2959412084046b234e3a5a01c82984e62f829bb8
+generated: "2022-11-30T16:43:29.268852-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.15
+version: 1.13.16
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.15](https://img.shields.io/badge/Version-1.13.15-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.16](https://img.shields.io/badge/Version-1.13.16-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #925](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/925)

## Description

Adding new environment variables so discovery ui/api/streams can have different urls. Leaving old environment variables in place for now to not break existing code. Will remove in a separate PR once other changes are merged.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
~- [ ] If global values were altered, are they included as chart default values?~
  ~- [ ] Are they also specified in the urbanos chart values file?~
~- [ ] If references to external charts were added:~
  ~- [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?~
  ~- [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?~
