### PR TITLE
update chart for FF

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.7
+version: 1.5.8
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.7](https://img.shields.io/badge/Version-1.5.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -32,6 +32,7 @@ A helm chart for the discovery ui
 | env.logo_url | string | `nil` |  |
 | env.mapbox_access_token | string | `""` |  |
 | env.primary_color | string | `"#1890ff"` |  |
+| env.regenerate_api_key_ff | bool | `true` |  |
 | env.streets_tile_layer_url | string | `"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.ingress.dnsZone | string | `"localhost"` |  |

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -25,5 +25,6 @@ data:
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
     window.PRIMARY_COLOR = '{{.Values.env.primary_color}}'
     window.REQUIRE_API_KEY = '{{.Values.global.require_api_key}}'
+    window.REGENERATE_API_KEY_FF: true = '{{.Values.env.regenerate_api_key_ff}}'
   nginx-csps.conf: |
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.amazonaws.com *.mapbox.com {{ .Values.env.additional_csp_hosts }} *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly http://localhost:*; worker-src blob:;";

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -25,6 +25,6 @@ data:
     window.AUTH0_AUDIENCE = '{{.Values.env.auth0_audience}}'
     window.PRIMARY_COLOR = '{{.Values.env.primary_color}}'
     window.REQUIRE_API_KEY = '{{.Values.global.require_api_key}}'
-    window.REGENERATE_API_KEY_FF: true = '{{.Values.env.regenerate_api_key_ff}}'
+    window.REGENERATE_API_KEY_FF = '{{.Values.env.regenerate_api_key_ff}}'
   nginx-csps.conf: |
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com *.google-analytics.com; style-src 'self' 'unsafe-inline'; frame-src *.auth0.com; img-src 'self' *.amazonaws.com *.mapbox.com {{ .Values.env.additional_csp_hosts }} *.google-analytics.com *.google.com *.doubleclick.net data: blob:; connect-src 'self' {{ .Values.env.additional_csp_hosts }} *.auth0.com *.mapbox.com *.plot.ly http://localhost:*; worker-src blob:;";

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -44,6 +44,7 @@ env:
   auth0_client_id: ""
   auth0_audience: ""
   additional_csp_hosts: ""
+  regenerate_api_key_ff: true
 
 nodeSelector: {}
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.7
+  version: 1.5.8
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:97f74489cafb5ecaae2706a67f178445794079c6b332e6e67a32ff926e8774c5
-generated: "2022-12-02T15:41:46.21549-05:00"
+digest: sha256:c947a37374d61f8395df37db8792242a585c1654603820a21585dbbf2fca6d5f
+generated: "2022-12-02T16:32:30.001656-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.17
+version: 1.13.18
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.17](https://img.shields.io/badge/Version-1.13.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.18](https://img.shields.io/badge/Version-1.13.18-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #505](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/505)


## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [x] Are they also specified in the urbanos chart values file?
- [x] If references to external charts were added:
  - [x] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [x] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
