### PR TITLE
Putting back mistakenly removed if clause

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ What was changed
 - [ ] Did you up the relevant chart version numbers? (If appropriate)
   - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
   - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
-- [ ] If chart values added, were default values provided in the chart? (Will `helm template . -f values.yaml` pass?)
+- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
 - [ ] Do you have git hooks installed? (See README.md to install)
 - [ ] If global values were altered, are they included as chart default values?
   - [ ] Are they also specified in the urbanos chart values file?

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.9
+version: 1.5.10
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.9](https://img.shields.io/badge/Version-1.5.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.10](https://img.shields.io/badge/Version-1.5.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -4,6 +4,7 @@ metadata:
   name: discovery-ui-configs
 data:
   config.js: |
+    {{ if .Values.env.contribute_host }}
     window.CONTRIBUTE_HOST = '{{.Values.env.contribute_host}}'
     {{ end -}}
     window.GTM_ID = '{{.Values.env.gtm_id}}'

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.9
+  version: 1.5.10
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:8c6c79f4be5b4b281b5ba1782530d7316a233b86e36b58281b21d01da5192377
-generated: "2022-12-05T15:37:32.393735-05:00"
+digest: sha256:a3cf89370070d1494943f2d28e3522d323de77a7b8c9321c3b126aadfb9b1fa0
+generated: "2022-12-05T15:55:15.68549-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.19
+version: 1.13.20
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.19](https://img.shields.io/badge/Version-1.13.19-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.20](https://img.shields.io/badge/Version-1.13.20-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link 925](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/925)

## Description

Accidentally removed the if clause in the last PR around discovery ui's contribute host variable. Putting it back.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?