### PR TITLE
Add Raptor client, make auth0 template for configurable

### DIFF
--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.20
+version: 1.13.21
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/templates/auth0-config.yaml
+++ b/charts/urban-os/templates/auth0-config.yaml
@@ -10,10 +10,10 @@ data:
         "clients": {
             "Discovery": {
                 {{- $localhost := "http://localhost:9001" -}}
-                {{- $uiInternal := print "https://discovery." .Release.Namespace "." .Values.global.ingress.dnsZone -}}
-                {{- $uiExternal := print "https://discovery." .Release.Namespace "." .Values.global.ingress.rootDnsZone -}}
-                {{- $apiInternal := print "https://data." .Release.Namespace "." .Values.global.ingress.dnsZone -}}
-                {{- $apiExternal := print "https://data." .Release.Namespace "." .Values.global.ingress.rootDnsZone -}}
+                {{- $uiInternal := print "https://" .Values.discovery-ui.subdomain "." .Values.global.ingress.dnsZone -}}
+                {{- $uiExternal := print "https://" .Values.discovery-ui.subdomain "." .Values.global.ingress.rootDnsZone -}}
+                {{- $apiInternal := print "https://" .Values.discovery-api.subdomain "." .Values.global.ingress.dnsZone -}}
+                {{- $apiExternal := print "https://" .Values.discovery-api.subdomain "." .Values.global.ingress.rootDnsZone -}}
                 "callbacks": "[\"{{ $localhost }}/oauth\", \"{{ $uiInternal }}/oauth\", \"{{ $uiExternal }}/oauth\", \"{{ $apiInternal }}/tableau/connector.html\", \"{{ $apiExternal }}/tableau/connector.html\"]",
                 "allowedLogoutUrls": "[\"{{ $localhost }}/oauth\", \"{{ $uiInternal }}/oauth\", \"{{ $uiExternal }}/oauth\"]",
                 "allowedOrigins": "[\"{{ $localhost }}\", \"{{ $uiInternal }}\", \"{{ $uiExternal }}\",\"{{ $apiInternal }}\", \"{{ $apiExternal }}\"]",
@@ -24,16 +24,20 @@ data:
             "ANDI": {
                 {{- $andiProtocol := ternary "https://" "http://" .Values.andi.ingress.tls -}}
                 {{- $nipio := "https://127.0.0.1.nip.io:4443" -}}
-                {{- $andiInternal := print $andiProtocol "andi." .Release.Namespace "." .Values.global.ingress.dnsZone -}}
-                {{- $andiExternal := print $andiProtocol "andi." .Release.Namespace "." .Values.global.ingress.rootDnsZone -}}
-                {{- $shareDataInternal := print $andiProtocol "sharedata." .Release.Namespace "." .Values.global.ingress.dnsZone -}}
-                {{- $shareDataExternal := print $andiProtocol "sharedata." .Release.Namespace "." .Values.global.ingress.rootDnsZone -}}
+                {{- $andiInternal := print $andiProtocol .Values.andi.subdomain "." .Values.global.ingress.dnsZone -}}
+                {{- $andiExternal := print $andiProtocol .Values.andi.subdomain "." .Values.global.ingress.rootDnsZone -}}
+                {{- $shareDataInternal := print $andiProtocol .Values.andi.shareSubdomain "." .Values.global.ingress.dnsZone -}}
+                {{- $shareDataExternal := print $andiProtocol .Values.andi.shareSubdomain "." .Values.global.ingress.rootDnsZone -}}
                 "callbacks": "[\"{{ $nipio }}/auth/auth0/callback\", \"{{ $andiInternal }}/auth/auth0/callback\", \"{{ $andiExternal }}/auth/auth0/callback\", \"{{ $shareDataInternal }}/auth/auth0/callback\", \"{{ $shareDataExternal }}/auth/auth0/callback\"]",
                 "allowedLogoutUrls": "[\"{{ $nipio }}/auth/auth0\", \"{{ $andiInternal }}/auth/auth0\", \"{{ $andiExternal }}/auth/auth0\", \"{{ $shareDataInternal }}/auth/auth0\", \"{{ $shareDataExternal }}/auth/auth0\"]",
                 "allowedOrigins": "[\"{{ $nipio }}\", \"{{ $andiInternal }}\", \"{{ $andiExternal }}\", \"{{ $shareDataInternal }}\", \"{{ $shareDataExternal }}\"]",
                 "webOrigins": "[\"{{ $nipio }}\", \"{{ $andiInternal }}\", \"{{ $andiExternal }}\", \"{{ $shareDataInternal }}\", \"{{ $shareDataExternal }}\"]",
                 "name": "ANDI",
                 "type": "regular_web"
+            },
+            "Raptor": {
+                "name": "Raptor",
+                "type": "non_interactive"
             }
         },
         "errorUrl": "{{ $uiExternal }}/oauth/error",

--- a/charts/urban-os/templates/auth0-config.yaml
+++ b/charts/urban-os/templates/auth0-config.yaml
@@ -36,8 +36,13 @@ data:
                 "type": "regular_web"
             },
             "Raptor": {
+                {{- $localhost := "http://localhost:4002" -}}
+                {{- $raptorInternal := print "https://" .Values.global.subdomains.raptor "." .Values.global.ingress.dnsZone -}}
+                {{- $raptorExternal := print "https://" .Values.global.subdomains.raptor "." .Values.global.ingress.rootDnsZone -}}
                 "name": "Raptor",
-                "type": "non_interactive"
+                "type": "non_interactive",
+                "allowedOrigins": "[\"{{ $localhost }}\", \"{{ $raptorInternal }}\", \"{{ $raptorExternal }}\"]",
+                "webOrigins": "[\"{{ $localhost }}\", \"{{ $raptorInternal }}\", \"{{ $raptorExternal }}\"]"
             }
         },
         "errorUrl": "{{ $uiExternal }}/oauth/error",

--- a/charts/urban-os/templates/auth0-config.yaml
+++ b/charts/urban-os/templates/auth0-config.yaml
@@ -10,10 +10,10 @@ data:
         "clients": {
             "Discovery": {
                 {{- $localhost := "http://localhost:9001" -}}
-                {{- $uiInternal := print "https://" .Values.discovery-ui.subdomain "." .Values.global.ingress.dnsZone -}}
-                {{- $uiExternal := print "https://" .Values.discovery-ui.subdomain "." .Values.global.ingress.rootDnsZone -}}
-                {{- $apiInternal := print "https://" .Values.discovery-api.subdomain "." .Values.global.ingress.dnsZone -}}
-                {{- $apiExternal := print "https://" .Values.discovery-api.subdomain "." .Values.global.ingress.rootDnsZone -}}
+                {{- $uiInternal := print "https://" .Values.global.subdomains.discoveryUi "." .Values.global.ingress.dnsZone -}}
+                {{- $uiExternal := print "https://" .Values.global.subdomains.discoveryUi "." .Values.global.ingress.rootDnsZone -}}
+                {{- $apiInternal := print "https://" .Values.global.subdomains.discoveryApi "." .Values.global.ingress.dnsZone -}}
+                {{- $apiExternal := print "https://" .Values.global.subdomains.discoveryApi "." .Values.global.ingress.rootDnsZone -}}
                 "callbacks": "[\"{{ $localhost }}/oauth\", \"{{ $uiInternal }}/oauth\", \"{{ $uiExternal }}/oauth\", \"{{ $apiInternal }}/tableau/connector.html\", \"{{ $apiExternal }}/tableau/connector.html\"]",
                 "allowedLogoutUrls": "[\"{{ $localhost }}/oauth\", \"{{ $uiInternal }}/oauth\", \"{{ $uiExternal }}/oauth\"]",
                 "allowedOrigins": "[\"{{ $localhost }}\", \"{{ $uiInternal }}\", \"{{ $uiExternal }}\",\"{{ $apiInternal }}\", \"{{ $apiExternal }}\"]",
@@ -24,10 +24,10 @@ data:
             "ANDI": {
                 {{- $andiProtocol := ternary "https://" "http://" .Values.andi.ingress.tls -}}
                 {{- $nipio := "https://127.0.0.1.nip.io:4443" -}}
-                {{- $andiInternal := print $andiProtocol .Values.andi.subdomain "." .Values.global.ingress.dnsZone -}}
-                {{- $andiExternal := print $andiProtocol .Values.andi.subdomain "." .Values.global.ingress.rootDnsZone -}}
-                {{- $shareDataInternal := print $andiProtocol .Values.andi.shareSubdomain "." .Values.global.ingress.dnsZone -}}
-                {{- $shareDataExternal := print $andiProtocol .Values.andi.shareSubdomain "." .Values.global.ingress.rootDnsZone -}}
+                {{- $andiInternal := print $andiProtocol .Values.global.subdomains.andi "." .Values.global.ingress.dnsZone -}}
+                {{- $andiExternal := print $andiProtocol .Values.global.subdomains.andi "." .Values.global.ingress.rootDnsZone -}}
+                {{- $shareDataInternal := print $andiProtocol .Values.global.subdomains.share "." .Values.global.ingress.dnsZone -}}
+                {{- $shareDataExternal := print $andiProtocol .Values.global.subdomains.share "." .Values.global.ingress.rootDnsZone -}}
                 "callbacks": "[\"{{ $nipio }}/auth/auth0/callback\", \"{{ $andiInternal }}/auth/auth0/callback\", \"{{ $andiExternal }}/auth/auth0/callback\", \"{{ $shareDataInternal }}/auth/auth0/callback\", \"{{ $shareDataExternal }}/auth/auth0/callback\"]",
                 "allowedLogoutUrls": "[\"{{ $nipio }}/auth/auth0\", \"{{ $andiInternal }}/auth/auth0\", \"{{ $andiExternal }}/auth/auth0\", \"{{ $shareDataInternal }}/auth/auth0\", \"{{ $shareDataExternal }}/auth/auth0\"]",
                 "allowedOrigins": "[\"{{ $nipio }}\", \"{{ $andiInternal }}\", \"{{ $andiExternal }}\", \"{{ $shareDataInternal }}\", \"{{ $shareDataExternal }}\"]",

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -42,6 +42,7 @@ global:
     share: "sharedata"
     discoveryApi: "data"
     discoveryUi: "discovery"
+    raptor: "raptor"
 
 
 # -- See dependent chart for configuration details

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -37,6 +37,11 @@ global:
     accessKey: []
     accessSecret: []
     hiveStoragePath: ""
+  subdomains:
+    andi: "andi"
+    share: "sharedata"
+    discoveryApi: "data"
+    discoveryUi: "discovery"
 
 
 # -- See dependent chart for configuration details
@@ -48,14 +53,11 @@ alchemist:
 andi:
   fullnameOverride: andi
   enabled: true
-  subdomain: "andi"
-  shareSubdomain: "sharedata"
 
 
 # -- See dependent chart for configuration details
 discovery-api:
   enabled: true
-  subdomain: "data"
   elasticsearch:
     # -- This is the default location of the chart-provided elasticsearch instance
     host: elasticsearch-master:9200
@@ -72,7 +74,6 @@ discovery-streams:
 # -- See dependent chart for configuration details
 discovery-ui:
   enabled: true
-  subdomain: "discovery"
 
 
 # -- By default, the urbanOS chart stands up its own elasticsearch instance.

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -48,11 +48,14 @@ alchemist:
 andi:
   fullnameOverride: andi
   enabled: true
+  subdomain: "andi"
+  shareSubdomain: "sharedata"
 
 
 # -- See dependent chart for configuration details
 discovery-api:
   enabled: true
+  subdomain: "data"
   elasticsearch:
     # -- This is the default location of the chart-provided elasticsearch instance
     host: elasticsearch-master:9200
@@ -69,6 +72,7 @@ discovery-streams:
 # -- See dependent chart for configuration details
 discovery-ui:
   enabled: true
+  subdomain: "discovery"
 
 
 # -- By default, the urbanOS chart stands up its own elasticsearch instance.


### PR DESCRIPTION
## [Ticket Link 958](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/958)

## Description

Adding Raptor as a client to the auto-generated auth0 config. While doing this I noticed that aspects of the URLs for Andi and Discovery UI were hardcoded to specific subdomains which aren't relevant for all. Now these rely on a chart variable for the subdomain. I was originally going to put the subdomain under the relevant app (so it would be something like discovery-api.subdomain) rather than global (global.subdomains.discoveryApi) but helm template doesn't like the dashes in keys in the templated auth0 config. Instead they're under global.subdomains, which does have the advantage of all being in one place.

I didn't add callbacks to the Raptor client because those are urls which Auth0 calls after authentication, but in Raptor's case it's just doing a synchronous web call for authentication, so I don't believe the callback is needed. Similarly with the allowed logout urls, users won't be "logging out" per se since this is machine to machine and Raptor doesn't need to be redirected anywhere. But I believe the allowed origins and allowed web origins are needed to prevent CORS issues.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [x] Are they also specified in the urbanos chart values file?
- [x] If references to external charts were added:
  - [x] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [x] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
