### PR TITLE
added secondary, success, and error colors to charts

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.1
+version: 2.3.2
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square)
+![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 
@@ -67,9 +67,12 @@ REST API to allow for dataset definition ingestion
 | service.port | int | `80` |  |
 | service.targetPort | int | `4000` |  |
 | service.type | string | `"NodePort"` |  |
+| theme.errorColor | string | `"#B80000"` |  |
 | theme.headerText | string | `"Data Submission Tool"` |  |
 | theme.logo | string | `"/images/UrbanOS.svg"` |  |
-| theme.primaryColor | string | `"#1170C8"` |  |
+| theme.primaryColor | string | `"#0F64B3"` |  |
+| theme.secondaryColor | string | `"#1176D4"` |  |
+| theme.successColor | string | `"#008000"` |  |
 | tolerations[0].effect | string | `"NoExecute"` |  |
 | tolerations[0].key | string | `"example.run.public-worker"` |  |
 | tolerations[0].operator | string | `"Equal"` |  |

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -136,6 +136,12 @@ spec:
             value: '{{  .Values.theme.headerText }}'
           - name: ANDI_PRIMARY_COLOR
             value: '{{  .Values.theme.primaryColor }}'
+          - name: ANDI_SECONDARY_COLOR
+            value: '{{  .Values.theme.secondary }}'
+          - name: ANDI_SUCCESS_COLOR
+            value: '{{  .Values.theme.successColor }}'
+          - name: ANDI_ERROR_COLOR
+            value: '{{  .Values.theme.errorColor }}'
           - name: ANDI_FOOTER_LEFT_SIDE_TEXT
             value: '{{  .Values.footer.leftSideText }}'
           - name: ANDI_FOOTER_LEFT_SIDE_LINK

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -101,8 +101,11 @@ theme:
   logo: "/images/UrbanOS.svg"
   # header bar text
   headerText: "Data Submission Tool"
-  # Primary color can be any valid css. Examples - "#101010", "rgb(0,0,0)", "red"
-  primaryColor: "#1170C8"
+  # Color can be any valid css. Examples - "#101010", "rgb(0,0,0)", "red"
+  primaryColor: "#0F64B3"
+  secondaryColor: "#1176D4"
+  successColor: "#008000"
+  errorColor: "#B80000"
 
 footer:
   # footer text on left side with links on right side

--- a/charts/sauron/README.md
+++ b/charts/sauron/README.md
@@ -1,6 +1,6 @@
 # sauron
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.1
+  version: 2.3.2
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.8
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:a3cf89370070d1494943f2d28e3522d323de77a7b8c9321c3b126aadfb9b1fa0
-generated: "2022-12-05T15:55:15.68549-05:00"
+digest: sha256:137759f6d1537f921abbb9c9c6f1e7da94544bfb782b29364a3990f1ca68f67f
+generated: "2023-01-06T15:00:58.754722-06:00"

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.20](https://img.shields.io/badge/Version-1.13.20-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.21](https://img.shields.io/badge/Version-1.13.21-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
@@ -54,6 +54,11 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | global.redis.host | string | `"redis.external-services"` | The url to a Redis instance. *Note*: Most apps in the platform require access to a Redis instance, and one is not currently included in the chart. |
 | global.redis.password | string | `""` |  |
 | global.require_api_key | bool | `false` | Determines whether a user is required to log in in order to see public data in the discovery suite |
+| global.subdomains.andi | string | `"andi"` |  |
+| global.subdomains.discoveryApi | string | `"data"` |  |
+| global.subdomains.discoveryUi | string | `"discovery"` |  |
+| global.subdomains.raptor | string | `"raptor"` |  |
+| global.subdomains.share | string | `"sharedata"` |  |
 | global.vault.endpoint | string | `"vault:8200"` | A url to a vault instance. Reaper and Andi use vault to read and store secrets for dataset ingestion. *Note*: Currently, only the provided vault chart works with UrbanOS |
 | kafka.enabled | bool | `true` |  |
 | kubernetes-data-platform.enabled | bool | `false` |  |


### PR DESCRIPTION
## [Ticket Link #974](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/974)

Remove if not applicable

## Description

Added Secondary, Success, and Error Colors

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [x] Are they also specified in the urbanos chart values file?
- [x] If references to external charts were added:
  - [x] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [x] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
