### PR TITLE
Low contrast andi

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.2
+version: 2.3.3
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.3
+version: 2.3.4
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
           - name: ANDI_PRIMARY_COLOR
             value: '{{  .Values.theme.primaryColor }}'
           - name: ANDI_SECONDARY_COLOR
-            value: '{{  .Values.theme.secondary }}'
+            value: '{{  .Values.theme.secondaryColor }}'
           - name: ANDI_SUCCESS_COLOR
             value: '{{  .Values.theme.successColor }}'
           - name: ANDI_ERROR_COLOR

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.3
+  version: 2.3.4
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.8
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:2ae21317b45916515fda788a9b2c5723746ee604ff2104534d3598e0a1acb3cb
-generated: "2023-01-10T11:23:01.166323-06:00"
+digest: sha256:16c25b93210202ed1fe0b1f1dc7ab4fc4d51bd24a9be58fe591c95e5c354f8da
+generated: "2023-01-10T11:44:17.102221-06:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.2
+  version: 2.3.3
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.8
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:137759f6d1537f921abbb9c9c6f1e7da94544bfb782b29364a3990f1ca68f67f
-generated: "2023-01-06T15:00:58.754722-06:00"
+digest: sha256:2ae21317b45916515fda788a9b2c5723746ee604ff2104534d3598e0a1acb3cb
+generated: "2023-01-10T11:23:01.166323-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.21
+version: 1.13.22
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.22
+version: 1.13.23
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
