### PR TITLE
Increase contrast in discovery_ui via primary color

### DIFF
--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.10
+version: 1.5.11
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -32,7 +32,7 @@ env:
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
   footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
   footer_right_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
-  primary_color: "#1890ff"
+  primary_color: "#0F64B3"
   mapbox_access_token: ""
   auth0_domain: ""
   auth0_client_id: ""

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.10
+  version: 1.5.11
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.3
-digest: sha256:16c25b93210202ed1fe0b1f1dc7ab4fc4d51bd24a9be58fe591c95e5c354f8da
-generated: "2023-01-10T11:44:17.102221-06:00"
+digest: sha256:17799583c71935de1c4ce2580ce4cf08b7b93131b7e8884fb035631bcdc40c6d
+generated: "2023-01-12T10:49:04.335709-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.23
+version: 1.13.24
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## [Ticket Link #975](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/975)


## Description

Just changing the default color scheme in discovery_ui to have higher contrast against white text / backgrounds

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?