### PR TITLE
update charts readme for primary color in disc-ui

### DIFF
--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.3.4](https://img.shields.io/badge/Version-2.3.4-informational?style=flat-square)
+![Version: 2.3.6](https://img.shields.io/badge/Version-2.3.6-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.10](https://img.shields.io/badge/Version-1.5.10-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.11](https://img.shields.io/badge/Version-1.5.11-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 
@@ -29,7 +29,7 @@ A helm chart for the discovery ui
 | env.header_title | string | `"UrbanOS Data Discovery"` |  |
 | env.logo_url | string | `nil` |  |
 | env.mapbox_access_token | string | `""` |  |
-| env.primary_color | string | `"#1890ff"` |  |
+| env.primary_color | string | `"#0F64B3"` |  |
 | env.regenerate_api_key_ff | bool | `true` |  |
 | env.streets_tile_layer_url | string | `"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"` |  |
 | global.auth.auth0_domain | string | `""` |  |

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -32,7 +32,7 @@ env:
   footer_left_side_text: "© 2022 UrbanOS. All rights reserved."
   footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
   footer_right_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
-  primary_color: "#0F64B3"
+  primary_color: "#0F64B3" 
   mapbox_access_token: ""
   auth0_domain: ""
   auth0_client_id: ""

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.17](https://img.shields.io/badge/Version-1.2.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.19](https://img.shields.io/badge/Version-1.2.19-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.24](https://img.shields.io/badge/Version-1.13.24-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.25](https://img.shields.io/badge/Version-1.13.25-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
Previous PR didn't update the helm-docs. Turns out I had a different pre-commit hook, so the script that is supposed to add a pre-commit that updates the docs didn't add the hook.

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
