### PR TITLE
1012 add secureCookie property to andi

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.7
+version: 2.3.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -148,6 +148,8 @@ spec:
             value: '{{  .Values.footer.leftSideLink }}'
           - name: ANDI_FOOTER_RIGHT_LINKS
             value: '{{  .Values.footer.rightLinks }}'
+          - name: SECURE_COOKIE
+            value: {{ quote .Values.secureCookie }}
           {{ if .Values.aws.s3HostName }}
           - name: S3_HOST_NAME
             value: {{ .Values.aws.s3HostName }}

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -130,3 +130,5 @@ ingress:
   tls: true
   enabled: true
   annotations:
+
+secureCookie: "false"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.7
+  version: 2.3.8
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.8
@@ -53,5 +53,5 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.6
-digest: sha256:083ed646db56e016ac0e82e9a6a8ae29890df7a76bc8fb2d0635d861c1644072
-generated: "2023-01-14T18:01:44.512063-06:00"
+digest: sha256:c76dbccf51db69344f18287c87181bff392f338c2c9d94c1d7ecd8c5aca1a45e
+generated: "2023-01-17T10:23:37.238486-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.26
+version: 1.13.27
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## [Ticket Link #1012](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1012)

Add secureCookie property to allow toggling of secure cookies in different environments

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
