### PR TITLE
962 Define test trigger fix

### DIFF
--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -79,7 +79,7 @@ dependencies:
     repository: https://operator.min.io/
     condition: minio-tenant.enabled
     alias: minio-tenant
-  - name: perfomancetesting
+  - name: performancetesting
     version: 0.1.2
     repository: file://../performancetesting
     condition: performancetesting.enabled


### PR DESCRIPTION
## [Ticket Link #962](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/gh/urbanos-public/internal/962)

Remove if not applicable

## Description

In the previous merge the github action for releasing workflow failed due to a typo error on urbanos/Chart.yaml which is fixed in this PR

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
