### PR TITLE
fixing typo error on Chart.lock for performancetesting

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -53,8 +53,8 @@ dependencies:
 - name: tenant
   repository: https://operator.min.io/
   version: 4.5.6
-- name: perfomancetesting
+- name: performancetesting
   repository: file://../performancetesting
   version: 0.1.2
-digest: sha256:92f094e9099b7d085bc1180f5ebfc79880799784e3371bb7846bbc0140299dfe
-generated: "2023-01-25T09:58:53.66421368-06:00"
+digest: sha256:f19e28742a2f62b562673c37eeed56396ed65c9b23624ef55e63807aa3f031c7
+generated: "2023-01-30T11:44:40.4861874-06:00"


### PR DESCRIPTION
## [Ticket Link #962](app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/gh/urbanos-public/internal/962)

Remove if not applicable

## Description

PR for fixing typo error on Chart.lock for performancetesting

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
