### PR TITLE
updating version on performance test chart

### DIFF
--- a/charts/performancetesting/Chart.yaml
+++ b/charts/performancetesting/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: performancetesting
 description: Cronjob for executing the system test image on cadence
 type: application
-version: 0.1.2
+version: 0.1.3
 icon: https://github.com/UrbanOS-Public

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -55,6 +55,6 @@ dependencies:
   version: 4.5.6
 - name: performancetesting
   repository: file://../performancetesting
-  version: 0.1.2
-digest: sha256:f19e28742a2f62b562673c37eeed56396ed65c9b23624ef55e63807aa3f031c7
-generated: "2023-01-30T11:44:40.4861874-06:00"
+  version: 0.1.3
+digest: sha256:254cdca04d01ad30d2747d32d1ba2a0dd7b751f7668bbbc6b7c692efebf280c6
+generated: "2023-01-30T16:50:04.5768263-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.30
+version: 1.13.31
 
 dependencies:
   - name: alchemist
@@ -80,6 +80,6 @@ dependencies:
     condition: minio-tenant.enabled
     alias: minio-tenant
   - name: performancetesting
-    version: 0.1.2
+    version: 0.1.3
     repository: file://../performancetesting
     condition: performancetesting.enabled


### PR DESCRIPTION
## [Ticket Link #962](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/gh/urbanos-public/internal/962)

Remove if not applicable

## Description

updating version on performance test chart

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
