### PR TITLE
US#1036-Performance-testing-image-issues

### DIFF
--- a/charts/performancetesting/Chart.yaml
+++ b/charts/performancetesting/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: performancetesting
 description: Cronjob for executing the system test image on cadence
 type: application
-version: 0.1.4
+version: 0.1.5
 icon: https://github.com/UrbanOS-Public

--- a/charts/performancetesting/templates/cron.yaml
+++ b/charts/performancetesting/templates/cron.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: prueba1
+  name: {{ .Chart.Name }}-cron
   namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: performancetest

--- a/charts/performancetesting/templates/cron.yaml
+++ b/charts/performancetesting/templates/cron.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Chart.Name }}-cron
+  name: prueba1
   namespace: {{ .Values.namespace }}
   labels:
     app.kubernetes.io/name: performancetest
@@ -26,9 +26,9 @@ spec:
                 cpu: {{ .Values.resources.limits.cpu }}
             env:
             - name: ANDI_URL
-              value: {{ .Values.performancetesting.ANDI_URL }}
+              value: {{ .Values.performancetesting.endpoints.ANDI_URL }}
             - name: DISCOVERY_URL
-              value: {{ .Values.performancetesting.DISCOVERY_URL }}
+              value: {{ .Values.performancetesting.endpoints.DISCOVERY_URL }}
             - name: API_KEY
-              value: {{ .Values.performancetesting.API_KEY }}
+              value: {{ .Values.performancetesting.endpoints.API_KEY }}
           restartPolicy: {{ .Values.restartPolicy }}

--- a/charts/performancetesting/values.yaml
+++ b/charts/performancetesting/values.yaml
@@ -11,7 +11,7 @@ resources: #jar file is running with a flag -Xmx1024m
   limits:
     memory: 1Gi
     cpu: 500m
-performancetesting:
+endpoints:
   ANDI_URL: ""
   DISCOVERY_URL: ""
   API_KEY: ""

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -55,6 +55,6 @@ dependencies:
   version: 4.5.6
 - name: performancetesting
   repository: file://../performancetesting
-  version: 0.1.5c
+  version: 0.1.5
 digest: sha256:ff311309785a521b80d985d8bba894f53054a66d65d2f137004ab9c2bcc137cb
 generated: "2023-02-20T14:35:53.5990014-06:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -55,6 +55,6 @@ dependencies:
   version: 4.5.6
 - name: performancetesting
   repository: file://../performancetesting
-  version: 0.1.4
-digest: sha256:4208b0935a92a14226c4ce407a85f0b9d38ddd517392a42c0333484882e852c4
-generated: "2023-02-16T09:22:35.8545457-06:00"
+  version: 0.1.5c
+digest: sha256:ff311309785a521b80d985d8bba894f53054a66d65d2f137004ab9c2bcc137cb
+generated: "2023-02-20T14:35:53.5990014-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.32
+version: 1.13.33
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -80,6 +80,6 @@ dependencies:
     condition: minio-tenant.enabled
     alias: minio-tenant
   - name: performancetesting
-    version: 0.1.4
+    version: 0.1.5
     repository: file://../performancetesting
     condition: performancetesting.enabled

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -257,5 +257,8 @@ valkyrie:
   replicaCount: 1
 
 performancetesting:
-  ANDI_URL: ""
   enabled: false
+  endpoints:
+    ANDI_URL: ""
+    DISCOVERY_URL: ""
+    API_KEY: ""


### PR DESCRIPTION
## Description

The enviroment variables were modified

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
