### PR TITLE
Add quotes where needed in clusterrole.yaml template

### DIFF
--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: "A combination of the community Prometheus and Grafana charts."
 name: monitoring
-version: 1.1.3
+version: 1.1.4
 
 dependencies:
   - name: prometheus

--- a/charts/monitoring/README.md
+++ b/charts/monitoring/README.md
@@ -1,6 +1,6 @@
 # monitoring
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A combination of the community Prometheus and Grafana charts.
 

--- a/charts/monitoring/templates/clusterrole.yaml
+++ b/charts/monitoring/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.prometheus.server.useExistingClusterRoleName }}
+  name: "{{ .Values.prometheus.server.useExistingClusterRoleName }}"
 rules:
   - apiGroups:
       - ""
@@ -23,10 +23,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: { { .Values.prometheus.server.useExistingClusterRoleName } }
+  name: "{{ .Values.prometheus.server.useExistingClusterRoleName }}"
 subjects:
   - kind: ServiceAccount
-    name: { { .Values.prometheus.serviceAccounts.server.name } }
-    namespace: {{ index .Values.prometheus.server.namespaces 0 }}
+    name: "{{ .Values.prometheus.serviceAccounts.server.name }}"
+    namespace: "{{ index .Values.prometheus.server.namespaces 0 }}"
 
 {{- end }}

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -34,7 +34,7 @@ dependencies:
   version: 1.0.7
 - name: monitoring
   repository: file://../monitoring
-  version: 1.1.3
+  version: 1.1.4
 - name: raptor
   repository: file://../raptor
   version: 1.1.7
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.7
-digest: sha256:f7bd78cb269376e65f2dc431ebb75a64f68731665411a6bd93e92457e32a3b71
-generated: "2023-03-06T15:18:31.32754-06:00"
+digest: sha256:073dc2be3affa8c967183001924933e7a5880ede4057925151b354a08aae4d09
+generated: "2023-03-08T15:20:47.079516-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.36
+version: 1.13.37
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.36](https://img.shields.io/badge/Version-1.13.36-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.37](https://img.shields.io/badge/Version-1.13.37-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION

Remove if not applicable

## Description

This fixes an error in deployment
```
Error: YAML parse error on urban-os/charts/monitoring/templates/clusterrole.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.prometheus.server.useExistingClusterRoleName":interface {}(nil)}
```

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?