### PR TITLE
bump everything in urbanos chart

### DIFF
--- a/charts/alchemist/Chart.yaml
+++ b/charts/alchemist/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Transforms data from the raw topic and writes it to transformed topic
 name: alchemist
-version: 1.0.4
+version: 1.0.5
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/alchemist

--- a/charts/alchemist/README.md
+++ b/charts/alchemist/README.md
@@ -1,6 +1,6 @@
 # alchemist
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Transforms data from the raw topic and writes it to transformed topic
 

--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.10
+version: 2.3.11
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.3.10](https://img.shields.io/badge/Version-2.3.10-informational?style=flat-square)
+![Version: 2.3.11](https://img.shields.io/badge/Version-2.3.11-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 

--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.8
+version: 1.4.9
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/README.md
+++ b/charts/discovery-api/README.md
@@ -1,6 +1,6 @@
 # discovery-api
 
-![Version: 1.4.8](https://img.shields.io/badge/Version-1.4.8-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 1.4.9](https://img.shields.io/badge/Version-1.4.9-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 A middleware layer to connect data consumers with the data sources
 

--- a/charts/discovery-streams/Chart.yaml
+++ b/charts/discovery-streams/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Dynamically find kafka topics and makes available corresponding channels on a public websocket
 name: discovery-streams
-version: 1.1.7
+version: 1.1.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_streams

--- a/charts/discovery-streams/README.md
+++ b/charts/discovery-streams/README.md
@@ -1,6 +1,6 @@
 # discovery-streams
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Dynamically find kafka topics and makes available corresponding channels on a public websocket
 

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.15
+version: 1.5.16
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/README.md
+++ b/charts/discovery-ui/README.md
@@ -1,6 +1,6 @@
 # discovery-ui
 
-![Version: 1.5.15](https://img.shields.io/badge/Version-1.5.15-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.5.16](https://img.shields.io/badge/Version-1.5.16-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A helm chart for the discovery ui
 

--- a/charts/estuary/Chart.yaml
+++ b/charts/estuary/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Reads the event stream and stores them in to event_stream table
 name: estuary
-version: 0.5.4
+version: 0.5.5
 deprecated: true

--- a/charts/estuary/README.md
+++ b/charts/estuary/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 0.5.4](https://img.shields.io/badge/Version-0.5.4-informational?style=flat-square)
+![Version: 0.5.5](https://img.shields.io/badge/Version-0.5.5-informational?style=flat-square)
 
 Reads the event stream and stores them in to event_stream table
 

--- a/charts/external-services/Chart.yaml
+++ b/charts/external-services/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0.0"
 description: Helm chart for external services. This is an optional abstraction layer for external dependencies such as redis.
 name: external-services
-version: 1.0.5
+version: 1.0.6

--- a/charts/external-services/README.md
+++ b/charts/external-services/README.md
@@ -1,6 +1,6 @@
 # external-services
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for external services. This is an optional abstraction layer for external dependencies such as redis.
 

--- a/charts/flair/Chart.yaml
+++ b/charts/flair/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: Watches data on the validated topic and does profiling on its path through the data pipeline.
 name: flair
-version: 2.1.2
+version: 2.1.3
 deprecated: true

--- a/charts/flair/README.md
+++ b/charts/flair/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 Watches data on the validated topic and does profiling on its path through the data pipeline.
 

--- a/charts/forklift/Chart.yaml
+++ b/charts/forklift/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Loads data from the transformed topic into Presto
 name: forklift
-version: 3.1.13
+version: 3.1.14
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/forklift

--- a/charts/forklift/README.md
+++ b/charts/forklift/README.md
@@ -1,6 +1,6 @@
 # forklift
 
-![Version: 3.1.13](https://img.shields.io/badge/Version-3.1.13-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 3.1.14](https://img.shields.io/badge/Version-3.1.14-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Loads data from the transformed topic into Presto
 

--- a/charts/kafka/Chart.lock
+++ b/charts/kafka/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: http://strimzi.io/charts/
   version: 0.31.1
 digest: sha256:d490e1670d0884a6419573fac6051c10b1cb367ece53939db2d55a3f244ffb29
-generated: "2023-01-25T16:21:16.765437-06:00"
+generated: "2023-03-09T10:14:31.794022-06:00"

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.20
+version: 1.2.21
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.20](https://img.shields.io/badge/Version-1.2.20-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.21](https://img.shields.io/badge/Version-1.2.21-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 

--- a/charts/kubernetes-data-platform/Chart.yaml
+++ b/charts/kubernetes-data-platform/Chart.yaml
@@ -1,7 +1,7 @@
 name: kubernetes-data-platform
 apiVersion: v1
 description: Hadoop-less data platform for the Smart City OS
-version: 1.7.3
+version: 1.7.4
 keywords:
   - presto
   - hive-metastore

--- a/charts/kubernetes-data-platform/README.md
+++ b/charts/kubernetes-data-platform/README.md
@@ -1,6 +1,6 @@
 # kubernetes-data-platform
 
-![Version: 1.7.3](https://img.shields.io/badge/Version-1.7.3-informational?style=flat-square)
+![Version: 1.7.4](https://img.shields.io/badge/Version-1.7.4-informational?style=flat-square)
 
 Hadoop-less data platform for the Smart City OS
 

--- a/charts/micro-service-watchinator/Chart.yaml
+++ b/charts/micro-service-watchinator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron job to watch microservices and make sure they are alive
 name: micro-service-watchinator
-version: 1.1.2
+version: 1.1.3
 deprecated: true

--- a/charts/micro-service-watchinator/README.md
+++ b/charts/micro-service-watchinator/README.md
@@ -2,7 +2,7 @@
 
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron job to watch microservices and make sure they are alive
 

--- a/charts/monitoring/Chart.yaml
+++ b/charts/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: "A combination of the community Prometheus and Grafana charts."
 name: monitoring
-version: 1.1.4
+version: 1.1.5
 
 dependencies:
   - name: prometheus

--- a/charts/monitoring/README.md
+++ b/charts/monitoring/README.md
@@ -1,6 +1,6 @@
 # monitoring
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A combination of the community Prometheus and Grafana charts.
 

--- a/charts/performancetesting/Chart.yaml
+++ b/charts/performancetesting/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: performancetesting
 description: Cronjob for executing the system test image on cadence
 type: application
-version: 0.1.7
+version: 0.1.8
 icon: https://github.com/UrbanOS-Public

--- a/charts/performancetesting/README.md
+++ b/charts/performancetesting/README.md
@@ -1,6 +1,6 @@
 # performancetesting
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Cronjob for executing the system test image on cadence
 

--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v2
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.7
+version: 1.0.8
 sources:
   - https://github.com/trinodb/trino
   - https://github.com/minio/operator

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square)
+![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 

--- a/charts/raptor/Chart.yaml
+++ b/charts/raptor/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Authenticate and authorize API users
 name: raptor
-version: 1.1.7
+version: 1.1.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/raptor

--- a/charts/raptor/README.md
+++ b/charts/raptor/README.md
@@ -1,6 +1,6 @@
 # raptor
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Authenticate and authorize API users
 

--- a/charts/reaper/Chart.yaml
+++ b/charts/reaper/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 name: reaper
-version: 1.2.8
+version: 1.2.9
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/reaper

--- a/charts/reaper/README.md
+++ b/charts/reaper/README.md
@@ -1,6 +1,6 @@
 # reaper
 
-![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.9](https://img.shields.io/badge/Version-1.2.9-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Elixir producer-consumer. Retrieves streamed data, and loads it onto a Kafka topic
 

--- a/charts/sauron/Chart.yaml
+++ b/charts/sauron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 name: sauron
-version: 0.0.16
+version: 0.0.17

--- a/charts/sauron/README.md
+++ b/charts/sauron/README.md
@@ -1,6 +1,6 @@
 # sauron
 
-![Version: 0.0.16](https://img.shields.io/badge/Version-0.0.16-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.0.17](https://img.shields.io/badge/Version-0.0.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -1,49 +1,49 @@
 dependencies:
 - name: alchemist
   repository: file://../alchemist
-  version: 1.0.4
+  version: 1.0.5
 - name: andi
   repository: file://../andi
-  version: 2.3.10
+  version: 2.3.11
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.4.8
+  version: 1.4.9
 - name: discovery-streams
   repository: file://../discovery-streams
-  version: 1.1.7
+  version: 1.1.8
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.15
+  version: 1.5.16
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
 - name: external-services
   repository: file://../external-services
-  version: 1.0.5
+  version: 1.0.6
 - name: forklift
   repository: file://../forklift
-  version: 3.1.13
+  version: 3.1.14
 - name: kafka
   repository: file://../kafka
-  version: 1.2.20
+  version: 1.2.21
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
-  version: 1.7.3
+  version: 1.7.4
 - name: persistence
   repository: file://../persistence
-  version: 1.0.7
+  version: 1.0.8
 - name: monitoring
   repository: file://../monitoring
-  version: 1.1.4
+  version: 1.1.5
 - name: raptor
   repository: file://../raptor
-  version: 1.1.7
+  version: 1.1.8
 - name: reaper
   repository: file://../reaper
-  version: 1.2.8
+  version: 1.2.9
 - name: valkyrie
   repository: file://../valkyrie
-  version: 2.6.7
+  version: 2.6.8
 - name: vault
   repository: https://helm.releases.hashicorp.com
   version: 0.22.0
@@ -55,6 +55,6 @@ dependencies:
   version: 4.5.6
 - name: performancetesting
   repository: file://../performancetesting
-  version: 0.1.7
-digest: sha256:073dc2be3affa8c967183001924933e7a5880ede4057925151b354a08aae4d09
-generated: "2023-03-08T15:20:47.079516-06:00"
+  version: 0.1.8
+digest: sha256:f41b6482601647721c3f568539a3e4083b0c800dcdbb68c9df79125999f26013
+generated: "2023-03-09T10:17:44.864482-06:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.37
+version: 1.13.38
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.37](https://img.shields.io/badge/Version-1.13.37-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.38](https://img.shields.io/badge/Version-1.13.38-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 

--- a/charts/valkyrie/Chart.yaml
+++ b/charts/valkyrie/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Validates data from raw topic and writes it to validated topic
 name: valkyrie
-version: 2.6.7
+version: 2.6.8
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/valkyrie

--- a/charts/valkyrie/README.md
+++ b/charts/valkyrie/README.md
@@ -1,6 +1,6 @@
 # valkyrie
 
-![Version: 2.6.7](https://img.shields.io/badge/Version-2.6.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 2.6.8](https://img.shields.io/badge/Version-2.6.8-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Validates data from raw topic and writes it to validated topic
 


### PR DESCRIPTION
## Description

To un-confuse the helm deploy, every version within the urbanos chart has been bumped.
`helm dep up` was also run in the four charts with dependencies, `preformancetesting`, `kafka`, `monitoring`, and `urbanos`, and the two lockfiles yielded have been included.

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
