### PR TITLE
Added require_admin_api_key for andi

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.10
+version: 2.3.11
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/README.md
+++ b/charts/andi/README.md
@@ -1,6 +1,6 @@
 # andi
 
-![Version: 2.3.10](https://img.shields.io/badge/Version-2.3.10-informational?style=flat-square)
+![Version: 2.3.11](https://img.shields.io/badge/Version-2.3.11-informational?style=flat-square)
 
 REST API to allow for dataset definition ingestion
 
@@ -26,6 +26,7 @@ REST API to allow for dataset definition ingestion
 | fullnameOverride | string | `""` |  |
 | global.auth.auth0_domain | string | `""` |  |
 | global.auth.jwt_issuer | string | `""` |  |
+| global.auth.raptor_url | string | `""` |  |
 | global.ingress.dnsZone | string | `"localhost"` |  |
 | global.ingress.rootDnsZone | string | `"localhost"` |  |
 | global.kafka.brokers | string | `"streaming-service-kafka-bootstrap:9092"` |  |
@@ -37,6 +38,7 @@ REST API to allow for dataset definition ingestion
 | global.redis.passwordSecret | string | `""` |  |
 | global.redis.port | int | `6379` |  |
 | global.redis.sslEnabled | bool | `false` |  |
+| global.require_admin_api_key | bool | `false` |  |
 | global.vault.endpoint | string | `"urban-os-vault:8200"` |  |
 | image.majorPin | string | `""` |  |
 | image.minorPin | string | `""` |  |

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -157,6 +157,10 @@ spec:
             value: {{ quote .Values.aws.s3Port }}
           - name: ALLOWED_ORIGIN
             value: "{{ .Values.ingress.tls | ternary "https" "http" }}://*.{{ .Values.global.ingress.dnsZone }}"
+          - name: RAPTOR_URL
+            value: {{ quote .Values.global.auth.raptor_url }}
+          - name: REQUIRE_ADMIN_API_KEY
+            value: {{ quote .Values.global.require_admin_api_key }}
           {{ end -}}
 {{- with .Values.tolerations }}
       tolerations:

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -2,6 +2,7 @@ global:
   auth:
     jwt_issuer: ""
     auth0_domain: ""
+    raptor_url: ""
   kafka:
     brokers: streaming-service-kafka-bootstrap:9092
   presto:
@@ -12,6 +13,7 @@ global:
     passwordSecret: ""
     password: ""
     sslEnabled: false
+  require_admin_api_key: false
   vault:
     # Should match the format {Release Name}-vault:8200
     endpoint: "urban-os-vault:8200"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.10
+  version: 2.3.11
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.8
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:d3b5c5740e0f283b9d332ece9e392a54df2f24ba870e4341cc0d9b42a7a9813b
-generated: "2023-03-09T11:02:23.397757-05:00"
+digest: sha256:74ddf2b7cd3d27da279f85a51b5c1728e0f5babbe7eeedf2f0097c2c1d54a72a
+generated: "2023-03-22T17:02:50.337728-04:00"

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -57,4 +57,4 @@ dependencies:
   repository: file://../performancetesting
   version: 0.1.8
 digest: sha256:74ddf2b7cd3d27da279f85a51b5c1728e0f5babbe7eeedf2f0097c2c1d54a72a
-generated: "2023-03-22T17:02:50.337728-04:00"
+generated: "2023-03-22T17:08:15.5-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.38
+version: 1.13.39
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -43,6 +43,7 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | forklift | object | `{"enabled":true,"fullnameOverride":"forklift"}` | See dependent chart for configuration details |
 | global.auth.auth0_domain | string | `""` |  |
 | global.auth.jwt_issuer | string | `""` |  |
+| global.auth.raptor_url | string | `""` |  |
 | global.buckets.hiveStorageBucket | string | `""` | Required. Bucket that extracted data is written to. *Note*: Bucket names are globally unique in S3 or cluster unique in Minio |
 | global.buckets.hostedFileBucket | string | `""` | Required. Bucket to store Host type datasets. *Note*: Bucket names are globally unique in S3 or cluster unique in Minio |
 | global.buckets.region | string | `"us-west-2"` | S3 Bucket region. Ignored when using Minio |
@@ -54,6 +55,7 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | global.presto.url | string | `"http://kubernetes-data-platform-presto:8080"` | This is the default url that presto is deployed to with the chart. Override this if you are using an external presto cluster. |
 | global.redis.host | string | `"redis.external-services"` | The url to a Redis instance. *Note*: Most apps in the platform require access to a Redis instance, and one is not currently included in the chart. |
 | global.redis.password | string | `""` |  |
+| global.require_admin_api_key | bool | `false` |  |
 | global.require_api_key | bool | `false` | Determines whether a user is required to log in in order to see public data in the discovery suite |
 | global.subdomains.andi | string | `"andi"` |  |
 | global.subdomains.discoveryApi | string | `"data"` |  |

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.38](https://img.shields.io/badge/Version-1.13.38-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.39](https://img.shields.io/badge/Version-1.13.39-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -2,6 +2,7 @@ global:
   auth:
     jwt_issuer: ""
     auth0_domain: ""
+    raptor_url: ""
   buckets:
     # -- S3 Bucket region. Ignored when using Minio
     region: "us-west-2"
@@ -17,6 +18,7 @@ global:
     url: http://kubernetes-data-platform-presto:8080
   # -- Determines whether a user is required to log in in order to see public data in the discovery suite
   require_api_key: false
+  require_admin_api_key: false
   redis:
     # -- The url to a Redis instance. *Note*: Most apps in the platform require access to a Redis instance, and one is not currently included in the chart.
     host: redis.external-services


### PR DESCRIPTION
## [Ticket Link #1107](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1107)

Remove if not applicable

## Description

Added require_admin_api_key for andi

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [x] If global values were altered, are they included as chart default values?
  - [x] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
