### PR TITLE
reverting kafka operator version

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.22
+version: 1.2.23
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.31.2
+    version: 0.31.1
     repository: http://strimzi.io/charts/
     condition: strimzi-kafka-operator.enabled

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.22](https://img.shields.io/badge/Version-1.2.22-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.23](https://img.shields.io/badge/Version-1.2.23-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 
@@ -13,7 +13,7 @@ A Helm chart for deploying kafka via strimzi
 
 | Repository | Name | Version |
 |------------|------|---------|
-| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.31.2 |
+| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.31.1 |
 
 ## Values
 

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.43
+version: 1.13.44
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.43](https://img.shields.io/badge/Version-1.13.43-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.44](https://img.shields.io/badge/Version-1.13.44-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
