### PR TITLE
Discovery api host config

### DIFF
--- a/charts/discovery-api/Chart.yaml
+++ b/charts/discovery-api/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0.0-static"
 description: A middleware layer to connect data consumers with the data sources
 name: discovery-api
-version: 1.4.10
+version: 1.4.11
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/discovery_api

--- a/charts/discovery-api/README.md
+++ b/charts/discovery-api/README.md
@@ -1,6 +1,6 @@
 # discovery-api
 
-![Version: 1.4.10](https://img.shields.io/badge/Version-1.4.10-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
+![Version: 1.4.11](https://img.shields.io/badge/Version-1.4.11-informational?style=flat-square) ![AppVersion: 1.0.0-static](https://img.shields.io/badge/AppVersion-1.0.0--static-informational?style=flat-square)
 
 A middleware layer to connect data consumers with the data sources
 
@@ -40,6 +40,7 @@ A middleware layer to connect data consumers with the data sources
 | global.redis.port | int | `6379` |  |
 | global.redis.sslEnabled | bool | `false` |  |
 | global.require_api_key | bool | `false` |  |
+| global.subdomains.discoveryApi | string | `""` |  |
 | global.vault.endpoint | string | `"vault.vault:8200"` |  |
 | image.majorPin | string | `""` |  |
 | image.minorPin | string | `""` |  |

--- a/charts/discovery-api/templates/deployment.yaml
+++ b/charts/discovery-api/templates/deployment.yaml
@@ -68,11 +68,7 @@ spec:
           - name: PRESTO_SCHEMA
             value: {{ .Values.presto.schema }}
           - name: HOST
-{{- if .Release.Namespace }}
-            value: data.{{ .Release.Namespace }}.{{ .Values.global.ingress.rootDnsZone }}
-{{- else }}
-            value: data.{{ .Values.global.ingress.rootDnsZone }}
-{{- end }}
+            value: {{ .Values.global.subdomains.discoveryApi }}.{{ .Values.global.ingress.rootDnsZone }}
           - name: ALLOWED_ORIGINS
             value: {{ .Values.global.ingress.rootDnsZone }},{{ .Values.global.ingress.dnsZone }}
           - name: PRESIGN_KEY

--- a/charts/discovery-api/values.yaml
+++ b/charts/discovery-api/values.yaml
@@ -25,6 +25,8 @@ global:
   objectStore:
     accessSecret: ""
     accessKey: ""
+  subdomains:
+    discoveryApi: ""
 
 resources:
   limits:

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.3.14
 - name: discovery-api
   repository: file://../discovery-api
-  version: 1.4.10
+  version: 1.4.11
 - name: discovery-streams
   repository: file://../discovery-streams
   version: 1.1.7
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:1c960a71fe0e81dd1606a80921c189f8682141479b5c52e396f31e3bb839c6d5
-generated: "2023-03-27T12:18:02.109054-05:00"
+digest: sha256:a1d04769bdfde51ddf31c8281a2ca5ce8becb8c789cc89d567b93400e09b00b6
+generated: "2023-04-03T12:56:54.535757-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.44
+version: 1.13.45
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.44](https://img.shields.io/badge/Version-1.13.44-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.45](https://img.shields.io/badge/Version-1.13.45-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
