### PR TITLE
Add kafka scraper to kafka exporter

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.23
+version: 1.2.24
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -37,7 +37,7 @@ A Helm chart for deploying kafka via strimzi
 | rbac.enabled | bool | `true` |  |
 | resizeHook.enabled | bool | `true` |  |
 | scraper.cron | string | `"*/10 * * * *"` |  |
-| scraper.enabled | bool | `true` |  |
+| scraper.enabled | bool | `false` |  |
 | scraper.endpoint | string | `"kafka-exporter:9308/metrics"` |  |
 | scraper.image | string | `"alpine:latest"` |  |
 | scraper.serviceAccount | string | `"default"` |  |

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.23](https://img.shields.io/badge/Version-1.2.23-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.24](https://img.shields.io/badge/Version-1.2.24-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 
@@ -36,6 +36,11 @@ A Helm chart for deploying kafka via strimzi
 | limitRange.enabled | bool | `true` |  |
 | rbac.enabled | bool | `true` |  |
 | resizeHook.enabled | bool | `true` |  |
+| scraper.cron | string | `"*/10 * * * *"` |  |
+| scraper.enabled | bool | `true` |  |
+| scraper.endpoint | string | `"kafka-exporter:9308/metrics"` |  |
+| scraper.image | string | `"alpine:latest"` |  |
+| scraper.serviceAccount | string | `"default"` |  |
 | strimzi-kafka-operator.enabled | bool | `true` |  |
 | strimzi-kafka-operator.resources.limits.cpu | string | `"500m"` |  |
 | strimzi-kafka-operator.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/kafka/templates/kafka-exporter/scraper.yaml
+++ b/charts/kafka/templates/kafka-exporter/scraper.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.scraper.enabled }}
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kafka-scraper-cron
+spec:
+  schedule: "{{ .Values.scraper.cron }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+          restartPolicy: Never
+          serviceAccount: "{{ .Values.scraper.serviceAccount }}"
+          containers:
+            - name: kafka-scraper
+              image: "{{ .Values.scraper.image }}"
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: 100Mi
+                  cpu: 100m
+                requests:
+                  memory: 100Mi
+                  cpu: 100m
+              command:
+                - "wget"
+                - "-qO-"
+                - "{{ .Values.scraper.endpoint }}"
+
+{{- end }}

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -18,7 +18,7 @@ kafka:
       memory: 12500M
 
 scraper:
-  enabled: true
+  enabled: false
   cron: "*/10 * * * *"
   image: "alpine:latest"
   endpoint: kafka-exporter:9308/metrics

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -17,6 +17,13 @@ kafka:
       cpu: 1400m
       memory: 12500M
 
+scraper:
+  enabled: true
+  cron: "*/10 * * * *"
+  image: "alpine:latest"
+  endpoint: kafka-exporter:9308/metrics
+  serviceAccount: default
+
 zookeeper:
   resources:
     requests:

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.13
 - name: kafka
   repository: file://../kafka
-  version: 1.2.23
+  version: 1.2.24
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.3
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:caea8eae7bc24a884b75488981dc69fbfe86b0691f8e036e66efd1d4fa8b3b80
-generated: "2023-04-04T10:52:42.851282-04:00"
+digest: sha256:9cd41e8e8f391438e184008976a63476d91c97336788f4e7bf8f9edd15e5fd71
+generated: "2023-04-18T15:12:45.810426-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.46
+version: 1.13.47
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.46](https://img.shields.io/badge/Version-1.13.46-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.47](https://img.shields.io/badge/Version-1.13.47-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #1103](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/1103)

## Description

Created a cron job that checks kafka-exporter and logs the metrics. 

## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
