### PR TITLE
Sauron remove specific namespace

### DIFF
--- a/charts/sauron/Chart.yaml
+++ b/charts/sauron/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 name: sauron
-version: 0.0.16
+version: 0.0.17

--- a/charts/sauron/README.md
+++ b/charts/sauron/README.md
@@ -1,6 +1,6 @@
 # sauron
 
-![Version: 0.0.16](https://img.shields.io/badge/Version-0.0.16-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.0.17](https://img.shields.io/badge/Version-0.0.17-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Cron jobs that watch remote deployments and images, issuing cluster commands as needed to update.
 

--- a/charts/sauron/templates/sauron-commands.yaml
+++ b/charts/sauron/templates/sauron-commands.yaml
@@ -25,7 +25,7 @@ data:
       echo "POD_NAME:"
       printf "%s \n\n" "$POD_NAME"
     
-      POD_IMAGE_TAG=$(kubectl get pod --namespace=dev "$POD_NAME" -o json | jq '.status.containerStatuses[] | .image ' | cut -d ':' -f 2 | sed 's/"//g' | tr -d '[:space:]')
+      POD_IMAGE_TAG=$(kubectl get pod --namespace="$NAMESPACE" "$POD_NAME" -o json | jq '.status.containerStatuses[] | .image ' | cut -d ':' -f 2 | sed 's/"//g' | tr -d '[:space:]')
       echo "POD_IMAGE_TAG:"
       printf "%s \n\n" "$POD_IMAGE_TAG"
     
@@ -79,7 +79,7 @@ data:
           return
         fi
         
-        CURRENT_DIGEST=$(kubectl get pod --namespace=dev $POD_NAME -o json | jq '.status.containerStatuses[] | .imageID ' | cut -d '@' -f 2 | sed 's/"//g' | tr -d '[:space:]')
+        CURRENT_DIGEST=$(kubectl get pod --namespace="$NAMESPACE" $POD_NAME -o json | jq '.status.containerStatuses[] | .imageID ' | cut -d '@' -f 2 | sed 's/"//g' | tr -d '[:space:]')
         echo "CURRENT_DIGEST:"
         echo "$CURRENT_DIGEST"
         CURRENT_DIGEST_LENGTH=${#CURRENT_DIGEST}


### PR DESCRIPTION
## Description

Removing the instances of a hard-coded namespace.

![Screenshot 2023-05-09 at 3 44 19 PM](https://github.com/UrbanOS-Public/charts/assets/54278348/81869c6f-b83e-472e-9990-756b39d35024)


## Reminders

- [x] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
