### PR TITLE
Modified charts to include custom favicon

### DIFF
--- a/charts/andi/Chart.yaml
+++ b/charts/andi/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: REST API to allow for dataset definition ingestion
 name: andi
-version: 2.3.14
+version: 2.3.15
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/andi

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
           - name: ANDI_FOOTER_RIGHT_LINKS
             value: '{{  .Values.footer.rightLinks }}'
           - name: CUSTOM_FAV_ICON_URL
-            value: '{{  .Values.theme.customFavIconBase64 }}'
+            value: '{{  .Values.theme.customFavIconUrl }}'
           - name: SECURE_COOKIE
             value: {{ quote .Values.secureCookie }}
           {{ if .Values.aws.s3HostName }}

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -158,6 +158,8 @@ spec:
             value: '{{  .Values.footer.leftSideLink }}'
           - name: ANDI_FOOTER_RIGHT_LINKS
             value: '{{  .Values.footer.rightLinks }}'
+          - name: CUSTOM_FAV_ICON_BASE64
+            value: '{{  .Values.theme.customFavIconBase64 }}'
           - name: SECURE_COOKIE
             value: {{ quote .Values.secureCookie }}
           {{ if .Values.aws.s3HostName }}

--- a/charts/andi/templates/deployment.yaml
+++ b/charts/andi/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
             value: '{{  .Values.footer.leftSideLink }}'
           - name: ANDI_FOOTER_RIGHT_LINKS
             value: '{{  .Values.footer.rightLinks }}'
-          - name: CUSTOM_FAV_ICON_BASE64
+          - name: CUSTOM_FAV_ICON_URL
             value: '{{  .Values.theme.customFavIconBase64 }}'
           - name: SECURE_COOKIE
             value: {{ quote .Values.secureCookie }}

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -108,10 +108,7 @@ theme:
   secondaryColor: "#1176D4"
   successColor: "#008000"
   errorColor: "#B80000"
-  # base64 string for the favicon (optional).  If used, it is a base64-encoded gzipped version of the icon
-  # For instance:
-  # customFavIconBase64: "H4sICJYyW2QCA2Zhdmljb24uaWNvAGNgYARCAQEBBhDQYGRgEAPRQAwSUQBiRgYWsFwDAwIIILE36Gsx/G9hYNjcHs5AZaAAoZhQuIxKINKAgQnMNTZQgkgaG0BoJWNjCIOZ2YCgBf//U4YBodIDmz4BAAA="
-  customFavIconBase64: 
+  customFavIconUrl: 
 
 footer:
   # footer text on left side with links on right side

--- a/charts/andi/values.yaml
+++ b/charts/andi/values.yaml
@@ -108,6 +108,10 @@ theme:
   secondaryColor: "#1176D4"
   successColor: "#008000"
   errorColor: "#B80000"
+  # base64 string for the favicon (optional).  If used, it is a base64-encoded gzipped version of the icon
+  # For instance:
+  # customFavIconBase64: "H4sICJYyW2QCA2Zhdmljb24uaWNvAGNgYARCAQEBBhDQYGRgEAPRQAwSUQBiRgYWsFwDAwIIILE36Gsx/G9hYNjcHs5AZaAAoZhQuIxKINKAgQnMNTZQgkgaG0BoJWNjCIOZ2YCgBf//U4YBodIDmz4BAAA="
+  customFavIconBase64: 
 
 footer:
   # footer text on left side with links on right side

--- a/charts/discovery-ui/Chart.yaml
+++ b/charts/discovery-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A helm chart for the discovery ui
 name: discovery-ui
-version: 1.5.18
+version: 1.5.19
 sources:
   - https://github.com/UrbanOS-Public/discovery_ui
   - https://github.com/UrbanOS-Public/react_discovery_ui

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -14,6 +14,7 @@ data:
     window.STREETS_TILE_LAYER_URL = '{{.Values.env.streets_tile_layer_url}}'
     window.MAPBOX_ACCESS_TOKEN = '{{.Values.env.mapbox_access_token}}'
     window.LOGO_URL = '{{.Values.env.logo_url}}'
+    window.CUSTOM_FAV_ICON_BASE64 = '{{.Values.env.custom_favicon_base64}}'
     window.FOOTER_LEFT_SIDE_TEXT = '{{.Values.env.footer_left_side_text}}'
     window.FOOTER_LEFT_SIDE_LINK = '{{.Values.env.footer_left_side_link}}'
     window.FOOTER_RIGHT_LINKS = '{{.Values.env.footer_right_links}}'

--- a/charts/discovery-ui/templates/configs.yaml
+++ b/charts/discovery-ui/templates/configs.yaml
@@ -14,7 +14,7 @@ data:
     window.STREETS_TILE_LAYER_URL = '{{.Values.env.streets_tile_layer_url}}'
     window.MAPBOX_ACCESS_TOKEN = '{{.Values.env.mapbox_access_token}}'
     window.LOGO_URL = '{{.Values.env.logo_url}}'
-    window.CUSTOM_FAV_ICON_BASE64 = '{{.Values.env.custom_favicon_base64}}'
+    window.CUSTOM_FAV_ICON_URL = '{{.Values.env.custom_favicon_url}}'
     window.FOOTER_LEFT_SIDE_TEXT = '{{.Values.env.footer_left_side_text}}'
     window.FOOTER_LEFT_SIDE_LINK = '{{.Values.env.footer_left_side_link}}'
     window.FOOTER_RIGHT_LINKS = '{{.Values.env.footer_right_links}}'

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -33,6 +33,10 @@ env:
   footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
   footer_right_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
   primary_color: "#0F64B3"
+  # base64 string for the favicon (optional).  If used, it is a base64-encoded gzipped version of the icon
+  # For instance:
+  # custom_favicon_base64: "H4sICJYyW2QCA2Zhdmljb24uaWNvAGNgYARCAQEBBhDQYGRgEAPRQAwSUQBiRgYWsFwDAwIIILE36Gsx/G9hYNjcHs5AZaAAoZhQuIxKINKAgQnMNTZQgkgaG0BoJWNjCIOZ2YCgBf//U4YBodIDmz4BAAA="
+  custom_favicon_base64:   
   # omitting mapbox will default plot.ly to use openstreetmap.org
   mapbox_access_token: ""
   auth0_domain: ""

--- a/charts/discovery-ui/values.yaml
+++ b/charts/discovery-ui/values.yaml
@@ -33,10 +33,8 @@ env:
   footer_left_side_link: "https://github.com/UrbanOS-Public/smartcitiesdata"
   footer_right_links: '[{"linkText":"UrbanOS", "url":"https://github.com/UrbanOS-Public/smartcitiesdata"}]'
   primary_color: "#0F64B3"
-  # base64 string for the favicon (optional).  If used, it is a base64-encoded gzipped version of the icon
-  # For instance:
-  # custom_favicon_base64: "H4sICJYyW2QCA2Zhdmljb24uaWNvAGNgYARCAQEBBhDQYGRgEAPRQAwSUQBiRgYWsFwDAwIIILE36Gsx/G9hYNjcHs5AZaAAoZhQuIxKINKAgQnMNTZQgkgaG0BoJWNjCIOZ2YCgBf//U4YBodIDmz4BAAA="
-  custom_favicon_base64:   
+  # url string for the favicon (optional).  If used, it is a base64-encoded gzipped version of the icon
+  custom_favicon_url: null   
   # omitting mapbox will default plot.ly to use openstreetmap.org
   mapbox_access_token: ""
   auth0_domain: ""

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 1.0.4
 - name: andi
   repository: file://../andi
-  version: 2.3.14
+  version: 2.3.15
 - name: discovery-api
   repository: file://../discovery-api
   version: 1.4.11
@@ -13,7 +13,7 @@ dependencies:
   version: 1.1.7
 - name: discovery-ui
   repository: file://../discovery-ui
-  version: 1.5.18
+  version: 1.5.19
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.14.0
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:9cd41e8e8f391438e184008976a63476d91c97336788f4e7bf8f9edd15e5fd71
-generated: "2023-04-18T15:12:45.810426-05:00"
+digest: sha256:742efd00bd51af193de797e13323e66d474be342097b2ac3d085e1332c5b75b4
+generated: "2023-05-10T14:59:04.521187-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.47
+version: 1.13.48
 
 dependencies:
   - name: alchemist


### PR DESCRIPTION
## [Ticket Link 1174](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/gh/urbanos-public/internal/1174})

## Description

Modified charts to include custom favicon

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
