### PR TITLE
Update minio to 4.5.8

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -49,12 +49,12 @@ dependencies:
   version: 0.22.0
 - name: operator
   repository: https://operator.min.io/
-  version: 4.5.6
+  version: 4.5.8
 - name: tenant
   repository: https://operator.min.io/
-  version: 4.5.6
+  version: 4.5.8
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:742efd00bd51af193de797e13323e66d474be342097b2ac3d085e1332c5b75b4
-generated: "2023-05-10T14:59:04.521187-05:00"
+digest: sha256:3684a5493c62883be5fd8bc7e5a22ab2ff7edc7fc330ba6f0200c56b1cc4ceaf
+generated: "2023-05-19T14:35:05.9719006-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.48
+version: 1.13.49
 
 dependencies:
   - name: alchemist
@@ -70,12 +70,12 @@ dependencies:
     condition: vault.enabled
     version: "0.22.0"
   - name: operator
-    version: 4.5.6
+    version: 4.5.8
     repository: https://operator.min.io/
     condition: minio-operator.enabled
     alias: minio-operator
   - name: tenant
-    version: 4.5.6
+    version: 4.5.8
     repository: https://operator.min.io/
     condition: minio-tenant.enabled
     alias: minio-tenant


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

Updating minio operator to 4.5.8

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [x] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [x] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [x] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [x] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
