### PR TITLE
Upgraded minio to 5.0.6

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -49,12 +49,12 @@ dependencies:
   version: 0.22.0
 - name: operator
   repository: https://operator.min.io/
-  version: 4.5.8
+  version: 5.0.6
 - name: tenant
   repository: https://operator.min.io/
-  version: 4.5.8
+  version: 5.0.6
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.8
-digest: sha256:3b7ac85444c5d106bd6c29f4615833582c5e3040e018edc6fcd043352190be2e
-generated: "2023-06-07T14:32:00.823579-04:00"
+digest: sha256:ff723eac4ab8d6a252df4b5681aa1da40f9e3c070170a8469e006f1a9833c813
+generated: "2023-09-06T13:40:10.963787-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.51
+version: 1.13.53
 
 dependencies:
   - name: alchemist
@@ -70,12 +70,12 @@ dependencies:
     condition: vault.enabled
     version: "0.22.0"
   - name: operator
-    version: 4.5.8
+    version: 5.0.6
     repository: https://operator.min.io/
     condition: minio-operator.enabled
     alias: minio-operator
   - name: tenant
-    version: 4.5.8
+    version: 5.0.6
     repository: https://operator.min.io/
     condition: minio-tenant.enabled
     alias: minio-tenant

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.51](https://img.shields.io/badge/Version-1.13.51-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.53](https://img.shields.io/badge/Version-1.13.53-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
@@ -25,8 +25,8 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | file://../valkyrie | valkyrie | >= 1.0.0 |
 | https://helm.elastic.co | elasticsearch | 7.14.0 |
 | https://helm.releases.hashicorp.com | vault | 0.22.0 |
-| https://operator.min.io/ | minio-operator(operator) | 4.5.8 |
-| https://operator.min.io/ | minio-tenant(tenant) | 4.5.8 |
+| https://operator.min.io/ | minio-operator(operator) | 5.0.6 |
+| https://operator.min.io/ | minio-tenant(tenant) | 5.0.6 |
 
 ## Values
 
@@ -89,7 +89,6 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | minio-operator.operator.resources.requests.ephemeral-storage | string | `"500Mi"` |  |
 | minio-operator.operator.resources.requests.memory | string | `"256Mi"` |  |
 | minio-tenant.enabled | bool | `true` |  |
-| minio-tenant.secrets | bool | `false` |  |
 | minio-tenant.tenant.buckets[0].name | string | `"presto-hive-storage"` |  |
 | minio-tenant.tenant.certificate.requestAutoCert | bool | `false` |  |
 | minio-tenant.tenant.configuration.name | string | `"minio1-env-configuration"` |  |

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -92,8 +92,11 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | minio-tenant.tenant.buckets[0].name | string | `"presto-hive-storage"` |  |
 | minio-tenant.tenant.certificate.requestAutoCert | bool | `false` |  |
 | minio-tenant.tenant.configuration.name | string | `"minio1-env-configuration"` |  |
+| minio-tenant.tenant.env[0].name | string | `"MINIO_BROWSER_LOGIN_ANIMATION"` |  |
+| minio-tenant.tenant.env[0].value | string | `"off"` |  |
 | minio-tenant.tenant.exposeServices.console | bool | `true` |  |
 | minio-tenant.tenant.exposeServices.minio | bool | `true` |  |
+| minio-tenant.tenant.name | string | `"minio1"` |  |
 | minio-tenant.tenant.pools[0].affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].key | string | `"v1.min.io/tenant"` |  |
 | minio-tenant.tenant.pools[0].affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].operator | string | `"In"` |  |
 | minio-tenant.tenant.pools[0].affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].labelSelector.matchExpressions[0].values[0] | string | `"minio1"` |  |

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -154,7 +154,6 @@ minio-operator:
 
 minio-tenant:
   enabled: true
-  secrets: false
   tenant:
     configuration:
       name: minio1-env-configuration

--- a/charts/urban-os/values.yaml
+++ b/charts/urban-os/values.yaml
@@ -155,6 +155,10 @@ minio-operator:
 minio-tenant:
   enabled: true
   tenant:
+    env:
+      - name: MINIO_BROWSER_LOGIN_ANIMATION
+        value: "off"
+    name: minio1
     configuration:
       name: minio1-env-configuration
     buckets:


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

- Upgraded minio operator and tenant to 5.0.6
- Default disable Minio Browser Login Animation so that port forwarding works


## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
