### PR TITLE
change elasticsearch chart to latest version of v7

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.5.21
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 8.5.1
+  version: 7.17.3
 - name: external-services
   repository: file://../external-services
   version: 1.0.6
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:dfa8f5f8f74c04359bdbfb4471b922878207c1e548de8cfefba06bff35d325eb
-generated: "2023-10-31T09:10:06.111663-04:00"
+digest: sha256:529ffbde291139536a58bcb5f10442e90d50f99db5c0eb0d1a6b46d37d19f21d
+generated: "2023-11-03T12:56:55.410021-04:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.55
+version: 1.13.56
 
 dependencies:
   - name: alchemist
@@ -26,7 +26,7 @@ dependencies:
     condition: discovery-ui.enabled
     version: ">= 1.0.0"
   - name: elasticsearch
-    version: 8.5.1
+    version: 7.17.3
     repository: https://helm.elastic.co
     condition: elasticsearch.enabled
   - name: external-services

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.55](https://img.shields.io/badge/Version-1.13.55-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.56](https://img.shields.io/badge/Version-1.13.56-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
@@ -23,7 +23,7 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | file://../raptor | raptor | >= 1.0.0 |
 | file://../reaper | reaper | >= 1.0.0 |
 | file://../valkyrie | valkyrie | >= 1.0.0 |
-| https://helm.elastic.co | elasticsearch | 8.5.1 |
+| https://helm.elastic.co | elasticsearch | 7.17.3 |
 | https://helm.releases.hashicorp.com | vault | 0.22.0 |
 | https://operator.min.io/ | minio-operator(operator) | 5.0.6 |
 | https://operator.min.io/ | minio-tenant(tenant) | 5.0.6 |


### PR DESCRIPTION
## Description
Drop back down to major version 7 but upgrade to the latest minor version, which should include the kube api update we need but won't break security like v8

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
