### PR TITLE
Revert and bump minio

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.26
+version: 1.2.27
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.39.0
+    version: 0.31.1
     repository: http://strimzi.io/charts/
     condition: strimzi-kafka-operator.enabled

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.26](https://img.shields.io/badge/Version-1.2.26-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.27](https://img.shields.io/badge/Version-1.2.27-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 
@@ -13,7 +13,7 @@ A Helm chart for deploying kafka via strimzi
 
 | Repository | Name | Version |
 |------------|------|---------|
-| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.39.0 |
+| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.31.1 |
 
 ## Values
 

--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,11 +1,11 @@
 name: persistence
 apiVersion: v2
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.9
+version: 1.0.10
 sources:
   - https://github.com/trinodb/trino
   - https://github.com/minio/operator
 dependencies:
   - name: trino
-    version: 0.18.0
+    version: 0.8.0
     repository: https://trinodb.github.io/charts/

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square)
+![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 
@@ -13,7 +13,7 @@ Data persistence for UrbanOS using Trino and the Hive Metastore
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://trinodb.github.io/charts/ | trino | 0.18.0 |
+| https://trinodb.github.io/charts/ | trino | 0.8.0 |
 
 ## Values
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -25,13 +25,13 @@ dependencies:
   version: 3.1.15
 - name: kafka
   repository: file://../kafka
-  version: 1.2.26
+  version: 1.2.27
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.5
 - name: persistence
   repository: file://../persistence
-  version: 1.0.9
+  version: 1.0.10
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.8
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:5dd2f4e914a20b6b5555174d4e46481fb48e7b8bedb26347614c93f906663717
-generated: "2024-02-16T14:16:07.773853-05:00"
+digest: sha256:bd490744007c2b46cdda3bb27bc6be0ae0da6937d6fa11c80a4f9e0d3afdef15
+generated: "2024-03-07T13:40:34.049754-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.58
+version: 1.13.59
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.58](https://img.shields.io/badge/Version-1.13.58-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.59](https://img.shields.io/badge/Version-1.13.59-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## [Ticket Link #fill_in](https://app.zenhub.com/workspaces/mdot-615b97c1a5fde400126174f8/issues/urbanos-public/internal/{replace_with_number})

Remove if not applicable

## Description

What was changed

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
