### PR TITLE
remove deprecated trino configs

### DIFF
--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v2
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.11
+version: 1.0.12
 sources:
   - https://github.com/trinodb/trino
   - https://github.com/minio/operator

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.11](https://img.shields.io/badge/Version-1.0.11-informational?style=flat-square)
+![Version: 1.0.12](https://img.shields.io/badge/Version-1.0.12-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 
@@ -39,7 +39,7 @@ Data persistence for UrbanOS using Trino and the Hive Metastore
 | metastore.resources.limits.memory | string | `"2Gi"` |  |
 | metastore.resources.requests.cpu | int | `1` |  |
 | metastore.resources.requests.memory | string | `"2Gi"` |  |
-| trino.additionalCatalogs.hive | string | `"connector.name=hive\nhive.metastore.uri=thrift://hive-metastore:8000\nhive.metastore.username=padmin\nhive.metastore-timeout=360m\nhive.allow-drop-table=true\nhive.allow-rename-table=true\nhive.allow-drop-column=true\nhive.allow-rename-column=true\nhive.allow-add-column=true\nhive.s3.aws-access-key=EXAMPLE\nhive.s3.aws-secret-key=EXAMPLE\nhive.s3.path-style-access=true\nhive.s3.endpoint=http://minio:80\nhive.s3.ssl.enabled=false\n"` |  |
+| trino.additionalCatalogs.hive | string | `"connector.name=hive\nhive.metastore.uri=thrift://hive-metastore:8000\nhive.metastore.username=padmin\nhive.metastore-timeout=360m\nhive.s3.aws-access-key=EXAMPLE\nhive.s3.aws-secret-key=EXAMPLE\nhive.s3.path-style-access=true\nhive.s3.endpoint=http://minio:80\nhive.s3.ssl.enabled=false\n"` |  |
 | trino.coordinator.resources.limits.cpu | int | `1` |  |
 | trino.coordinator.resources.limits.memory | string | `"2Gi"` |  |
 | trino.coordinator.resources.requests.cpu | int | `1` |  |

--- a/charts/persistence/values.yaml
+++ b/charts/persistence/values.yaml
@@ -61,11 +61,6 @@ trino:
       hive.metastore.uri=thrift://hive-metastore:8000
       hive.metastore.username=padmin
       hive.metastore-timeout=360m
-      hive.allow-drop-table=true
-      hive.allow-rename-table=true
-      hive.allow-drop-column=true
-      hive.allow-rename-column=true
-      hive.allow-add-column=true
       hive.s3.aws-access-key=EXAMPLE
       hive.s3.aws-secret-key=EXAMPLE
       hive.s3.path-style-access=true

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 1.7.5
 - name: persistence
   repository: file://../persistence
-  version: 1.0.11
+  version: 1.0.12
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.8
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:cead4ad3e6e50cd046e7e6df9651f0152eb7244e0bd2c6c993ea79015bd20efb
-generated: "2024-04-03T15:09:42.534098-05:00"
+digest: sha256:9c7a59936fd08e8e5ee15e4097d81c840aa095ee80a475a2486a7708d5b29005
+generated: "2024-04-04T13:38:29.282881-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.60
+version: 1.13.61
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.60](https://img.shields.io/badge/Version-1.13.60-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.61](https://img.shields.io/badge/Version-1.13.61-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
