### PR TITLE
Latest updates after debugging sessions

### DIFF
--- a/charts/kafka/Chart.lock
+++ b/charts/kafka/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: strimzi-kafka-operator
   repository: http://strimzi.io/charts/
-  version: 0.31.1
-digest: sha256:d490e1670d0884a6419573fac6051c10b1cb367ece53939db2d55a3f244ffb29
-generated: "2023-01-25T16:21:16.765437-06:00"
+  version: 0.42.0
+digest: sha256:72bb7bd281d200f285f1d1e8a955f4caa21198992f0c6093397ae535b38e8e0a
+generated: "2024-08-20T08:36:36.002524-05:00"

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for deploying kafka via strimzi
 name: kafka
-version: 1.2.27
+version: 1.2.28
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
   - https://github.com/apache/kafka
 dependencies:
   - name: strimzi-kafka-operator
-    version: 0.31.1
+    version: 0.42.0
     repository: http://strimzi.io/charts/
     condition: strimzi-kafka-operator.enabled

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -1,6 +1,6 @@
 # kafka
 
-![Version: 1.2.27](https://img.shields.io/badge/Version-1.2.27-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.2.28](https://img.shields.io/badge/Version-1.2.28-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for deploying kafka via strimzi
 
@@ -13,7 +13,7 @@ A Helm chart for deploying kafka via strimzi
 
 | Repository | Name | Version |
 |------------|------|---------|
-| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.31.1 |
+| http://strimzi.io/charts/ | strimzi-kafka-operator | 0.42.0 |
 
 ## Values
 
@@ -31,7 +31,7 @@ A Helm chart for deploying kafka via strimzi
 | kafka.topics[0].name | string | `"streaming-persisted"` |  |
 | kafka.topics[1].name | string | `"streaming-dead-letters"` |  |
 | kafka.topics[2].name | string | `"event-stream"` |  |
-| kafka.version | string | `"2.6.2"` |  |
+| kafka.version | string | `"3.7.0"` |  |
 | kafkaExporter.enabled | bool | `true` |  |
 | limitRange.enabled | bool | `true` |  |
 | rbac.enabled | bool | `true` |  |

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -1,5 +1,5 @@
 kafka:
-  version: 2.6.2
+  version: 3.7.0
   broker: pipeline-kafka-bootstrap:9092
   storageSize: 100Gi
   defaultPartitions: 1

--- a/charts/persistence/Chart.yaml
+++ b/charts/persistence/Chart.yaml
@@ -1,7 +1,7 @@
 name: persistence
 apiVersion: v2
 description: Data persistence for UrbanOS using Trino and the Hive Metastore
-version: 1.0.13
+version: 1.0.14
 sources:
   - https://github.com/trinodb/trino
   - https://github.com/minio/operator

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -25,8 +25,8 @@ Data persistence for UrbanOS using Trino and the Hive Metastore
 | global.objectStore.hiveStoragePath | string | `"hive-s3"` |  |
 | global.objectStore.host | string | `"minio"` |  |
 | global.objectStore.port | int | `80` |  |
-| metastore.image.repository | string | `"quay.io/cloudservices/ubi-hive"` |  |
-| metastore.image.tag | string | `"3.1.3-metastore-042"` |  |
+| metastore.image.repository | string | `"quay.io/urbanos/ubi-hive"` |  |
+| metastore.image.tag | string | `"3.1.3-metastore-043-hadoop-3.3.6"` |  |
 | metastore.postgres.host | string | `"postgres"` |  |
 | metastore.postgres.name | string | `"metastore"` |  |
 | metastore.postgres.password | string | `"example"` |  |
@@ -39,7 +39,7 @@ Data persistence for UrbanOS using Trino and the Hive Metastore
 | metastore.resources.limits.memory | string | `"2Gi"` |  |
 | metastore.resources.requests.cpu | int | `1` |  |
 | metastore.resources.requests.memory | string | `"2Gi"` |  |
-| trino.additionalCatalogs.hive | string | `"connector.name=hive\nhive.metastore.uri=thrift://hive-metastore:8000\nhive.metastore.username=padmin\nhive.metastore-timeout=360m\nhive.s3.aws-access-key=EXAMPLE\nhive.s3.aws-secret-key=EXAMPLE\nhive.s3.path-style-access=true\nhive.s3.endpoint=http://minio:80\nhive.s3.ssl.enabled=false\n"` |  |
+| trino.additionalCatalogs.hive | string | `"connector.name=hive\nhive.metastore.uri=thrift://hive-metastore:8000\nhive.metastore.username=padmin\nhive.metastore-timeout=360m\nhive.allow-drop-table=true\nhive.allow-rename-table=true\nhive.allow-drop-column=true\nhive.allow-rename-column=true\nhive.allow-add-column=true\nhive.s3.aws-access-key=EXAMPLE\nhive.s3.aws-secret-key=EXAMPLE\nhive.s3.path-style-access=true\nhive.s3.endpoint=http://minio:80\nhive.s3.ssl.enabled=false\n"` |  |
 | trino.coordinator.resources.limits.cpu | int | `1` |  |
 | trino.coordinator.resources.limits.memory | string | `"2Gi"` |  |
 | trino.coordinator.resources.requests.cpu | int | `1` |  |

--- a/charts/persistence/README.md
+++ b/charts/persistence/README.md
@@ -1,6 +1,6 @@
 # persistence
 
-![Version: 1.0.13](https://img.shields.io/badge/Version-1.0.13-informational?style=flat-square)
+![Version: 1.0.14](https://img.shields.io/badge/Version-1.0.14-informational?style=flat-square)
 
 Data persistence for UrbanOS using Trino and the Hive Metastore
 

--- a/charts/persistence/values.yaml
+++ b/charts/persistence/values.yaml
@@ -12,8 +12,8 @@ global:
 
 metastore:
   image:
-    repository: quay.io/cloudservices/ubi-hive
-    tag: 3.1.3-metastore-042
+    repository: quay.io/urbanos/ubi-hive
+    tag: 3.1.3-metastore-043-hadoop-3.3.6
   rbac:
     enabled: true
   postgres:
@@ -61,6 +61,11 @@ trino:
       hive.metastore.uri=thrift://hive-metastore:8000
       hive.metastore.username=padmin
       hive.metastore-timeout=360m
+      hive.allow-drop-table=true
+      hive.allow-rename-table=true
+      hive.allow-drop-column=true
+      hive.allow-rename-column=true
+      hive.allow-add-column=true
       hive.s3.aws-access-key=EXAMPLE
       hive.s3.aws-secret-key=EXAMPLE
       hive.s3.path-style-access=true

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -25,7 +25,7 @@ dependencies:
   version: 3.1.15
 - name: kafka
   repository: file://../kafka
-  version: 1.2.27
+  version: 1.2.28
 - name: kubernetes-data-platform
   repository: file://../kubernetes-data-platform
   version: 1.7.5
@@ -49,12 +49,12 @@ dependencies:
   version: 0.27.0
 - name: operator
   repository: https://operator.min.io/
-  version: 5.0.12
+  version: 5.0.15
 - name: tenant
   repository: https://operator.min.io/
-  version: 5.0.12
+  version: 5.0.15
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:d883686db7fea15f6353ffcc98f1ba5d73af154751e07a7b3aedbe137f2b7ac5
-generated: "2024-04-11T14:36:34.025293-04:00"
+digest: sha256:b478120fc6b82f6a017d59fd3269eb3f0babeed33899fddce5c7c42a7bdfc737
+generated: "2024-08-01T12:47:11.629324-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.62
+version: 1.13.64
 
 dependencies:
   - name: alchemist
@@ -70,12 +70,12 @@ dependencies:
     condition: vault.enabled
     version: "0.27.0"
   - name: operator
-    version: 5.0.12
+    version: 5.0.15
     repository: https://operator.min.io/
     condition: minio-operator.enabled
     alias: minio-operator
   - name: tenant
-    version: 5.0.12
+    version: 5.0.15
     repository: https://operator.min.io/
     condition: minio-tenant.enabled
     alias: minio-tenant

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.62](https://img.shields.io/badge/Version-1.13.62-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.64](https://img.shields.io/badge/Version-1.13.64-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 
@@ -25,8 +25,8 @@ Master chart that deploys the UrbanOS platform. See the individual dependency re
 | file://../valkyrie | valkyrie | >= 1.0.0 |
 | https://helm.elastic.co | elasticsearch | 7.17.3 |
 | https://helm.releases.hashicorp.com | vault | 0.27.0 |
-| https://operator.min.io/ | minio-operator(operator) | 5.0.12 |
-| https://operator.min.io/ | minio-tenant(tenant) | 5.0.12 |
+| https://operator.min.io/ | minio-operator(operator) | 5.0.15 |
+| https://operator.min.io/ | minio-tenant(tenant) | 5.0.15 |
 
 ## Values
 


### PR DESCRIPTION
## Description

Kafka, Strimzi, Minio, and Metastore version upgrades

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
