### PR TITLE
update chart lock

### DIFF
--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -31,7 +31,7 @@ dependencies:
   version: 1.7.5
 - name: persistence
   repository: file://../persistence
-  version: 1.0.13
+  version: 1.0.14
 - name: monitoring
   repository: file://../monitoring
   version: 1.1.8
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:b478120fc6b82f6a017d59fd3269eb3f0babeed33899fddce5c7c42a7bdfc737
-generated: "2024-08-01T12:47:11.629324-05:00"
+digest: sha256:ab9b4d94c627c109ceed8afd0dbc0fd4502bbd08a3090a152ea04da5abbca513
+generated: "2024-08-20T08:47:35.777195-05:00"


### PR DESCRIPTION

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
