### PR TITLE
bump alchemist version to bring in memory changes

### DIFF
--- a/charts/alchemist/Chart.yaml
+++ b/charts/alchemist/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.0"
 description: Transforms data from the raw topic and writes it to transformed topic
 name: alchemist
-version: 1.0.6
+version: 1.0.7
 sources:
   - https://github.com/UrbanOS-Public/smartcitiesdata/tree/master/apps/alchemist

--- a/charts/alchemist/README.md
+++ b/charts/alchemist/README.md
@@ -1,6 +1,6 @@
 # alchemist
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Transforms data from the raw topic and writes it to transformed topic
 

--- a/charts/urban-os/Chart.lock
+++ b/charts/urban-os/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: alchemist
   repository: file://../alchemist
-  version: 1.0.6
+  version: 1.0.7
 - name: andi
   repository: file://../andi
   version: 2.3.19
@@ -56,5 +56,5 @@ dependencies:
 - name: performancetesting
   repository: file://../performancetesting
   version: 0.1.9
-digest: sha256:ab9b4d94c627c109ceed8afd0dbc0fd4502bbd08a3090a152ea04da5abbca513
-generated: "2024-08-20T08:47:35.777195-05:00"
+digest: sha256:9bed36c7b738a079bf08c3f25efc01a92b4c0469fab4fc700baea9bd37bbd379
+generated: "2024-08-23T09:09:58.17464-05:00"

--- a/charts/urban-os/Chart.yaml
+++ b/charts/urban-os/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 name: urban-os
-version: 1.13.64
+version: 1.13.65
 
 dependencies:
   - name: alchemist

--- a/charts/urban-os/README.md
+++ b/charts/urban-os/README.md
@@ -1,6 +1,6 @@
 # urban-os
 
-![Version: 1.13.64](https://img.shields.io/badge/Version-1.13.64-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 1.13.65](https://img.shields.io/badge/Version-1.13.65-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 Master chart that deploys the UrbanOS platform. See the individual dependency readmes for configuration options.
 


### PR DESCRIPTION
## Description
bump alchemist version to bring in memory changes

## Reminders

- [ ] Did you up the relevant chart version numbers? (If appropriate)
  - [ ] If you up a chart version within urban-os, have you also upped the urban-os chart version itself?
  - [ ] If charts within the urban-os chart (andi, etc) have been updated, have you run `helm dependency update` in /charts/urban-os and commited the Chart.lock file?
- [ ] Does `helm template . -f values.yaml` pass? (Checks for default values provided in chart and catches other errors)
- [ ] Do you have git hooks installed? (See README.md to install)
- [ ] If global values were altered, are they included as chart default values?
  - [ ] Are they also specified in the urbanos chart values file?
- [ ] If references to external charts were added:
  - [ ] Was the github release action updated to `helm update {new_thing}` it's dependencies?
  - [ ] Was the deploy repo `-u` flag updated to `helm update {new_thing}` to ensure it's not left out of deployments?
